### PR TITLE
Fix incorrect checks on the existance of the Lock-Token header in responses

### DIFF
--- a/NetFx/DecaTec.WebDav.NetFx/WebDavHelper.cs
+++ b/NetFx/DecaTec.WebDav.NetFx/WebDavHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace DecaTec.WebDav
@@ -16,10 +17,13 @@ namespace DecaTec.WebDav
         public static LockToken GetLockTokenFromWebDavResponseMessage(WebDavResponseMessage responseMessage)
         {
             // Try to get lock token from response header.
-            var lockTokenHeaderValue = responseMessage.Headers.GetValues(WebDavRequestHeader.LockTocken).FirstOrDefault();
-
-            if (lockTokenHeaderValue != null)
-                return new LockToken(lockTokenHeaderValue);
+            IEnumerable<string> lockTokenHeaderValues;
+            if (responseMessage.Headers.TryGetValues(WebDavRequestHeader.LockTocken, out lockTokenHeaderValues))
+            {
+                var lockTokenHeaderValue = lockTokenHeaderValues.FirstOrDefault();
+                if (lockTokenHeaderValue != null)
+                    return new LockToken(lockTokenHeaderValue);
+            }
 
             // If lock token was not submitted by response header, it should be found in the response content.
             try

--- a/Uwp/DecaTec.WebDav.Uwp/WebDavHelper.cs
+++ b/Uwp/DecaTec.WebDav.Uwp/WebDavHelper.cs
@@ -19,8 +19,7 @@ namespace DecaTec.WebDav
             // Try to get lock token from response header.
             string lockTokenHeaderValue;
             var success = responseMessage.Headers.TryGetValue(WebDavRequestHeader.LockTocken, out lockTokenHeaderValue);
-
-            if (!success)
+            if (success)
                 return new LockToken(lockTokenHeaderValue);
 
             // If lock token was not submitted by response header, it should be found in the response content.


### PR DESCRIPTION
For NetFx the GetValues method was used which throws in the requested values are not found, which defaults the purpose of the fallback on the lock token in the response content.

The Uwp implementation always threw in the LockToken constructor since it was only invoked if the header was not present.

Please note: I was not able to run the unit test suite due to issues with Visual Studio 2015, could you have a look at the proposed change?