### PR TITLE
Do not try to parse, de- or encode the absoluteURI.

### DIFF
--- a/DecaTec.WebDav/AbsoluteUri.cs
+++ b/DecaTec.WebDav/AbsoluteUri.cs
@@ -39,10 +39,12 @@ namespace DecaTec.WebDav
         }
 
         /// <summary>
-        /// Gets the string representation of this AbsoluteUri.
+        /// Gets the string representation of this <see cref="AbsoluteUri"/>.
         /// </summary>
-        /// <returns>The string representation of this AbsoluteUri.</returns>
-        public override string ToString() => absoluteUri.ToString();
+        /// <returns>The string representation of this <see cref="AbsoluteUri"/>.</returns>
+        /// <remarks>This ToString method returns the original string used to create this <see cref="AbsoluteUri"/>. 
+        /// This is according to specification, which states "Clients must not attempt to interpret lock tokens in any way.": http://www.webdav.org/specs/rfc4918.html#lock-tokens. </remarks>
+        public override string ToString() => absoluteUri.OriginalString;
 
         /// <summary>
         /// Tries to parse the given <paramref name="rawAbsoluteUri"/> into an <see cref="AbsoluteUri"/>.

--- a/UnitTests/DecaTec.WebDav.UnitTest/UnitTestAbsoluteUri.cs
+++ b/UnitTests/DecaTec.WebDav.UnitTest/UnitTestAbsoluteUri.cs
@@ -59,6 +59,56 @@ namespace DecaTec.WebDav.UnitTest
             var result = AbsoluteUri.TryParse(url, out var absoluteUri);
 
             Assert.IsFalse(result);
+            Assert.IsNull(absoluteUri);
         }
+
+        [TestMethod]
+        public void UT_AbsoluteUri_ToString_WithEncodedUri()
+        {
+            var input = "opaquelocktoken:dccce564-412e-11e1-b969-00059a3c7a00:%2fFolder%20Test%2fFile.xml";
+            AbsoluteUri uri;
+            var isParsed = AbsoluteUri.TryParse(input, out uri);
+            var actual = uri.ToString();
+
+            Assert.IsTrue(isParsed);
+            Assert.AreEqual(input, actual);
+        }
+
+        [TestMethod]
+        public void UT_AbsoluteUri_ToString_WithDecodedUri()
+        {
+            var input = "opaquelocktoken:dccce564-412e-11e1-b969-00059a3c7a00:/Folder Test/File.xml";
+            AbsoluteUri uri;
+            var isParsed = AbsoluteUri.TryParse(input, out uri);
+            var actual = uri.ToString();
+
+            Assert.IsTrue(isParsed);
+            Assert.AreEqual(input, actual);
+        }
+
+        [TestMethod]
+        public void UT_AbsoluteUri_ToString_WithEncodedSegment()
+        {
+            var input = "opaquelocktoken:dccce564-412e-11e1-b969-00059a3c7a00:/Folder%20Test/File.xml";
+            AbsoluteUri uri;
+            var isParsed = AbsoluteUri.TryParse(input, out uri);
+            var actual = uri.ToString();
+
+            Assert.IsTrue(isParsed);
+            Assert.AreEqual(input, actual);
+        }
+
+        [TestMethod]
+        public void UT_AbsoluteUri_ToString_WithDecodedSegment()
+        {
+            var input = "opaquelocktoken:dccce564-412e-11e1-b969-00059a3c7a00:%2fFolder Test%2fFile.xml";
+            AbsoluteUri uri;
+            var isParsed = AbsoluteUri.TryParse(input, out uri);
+            var actual = uri.ToString();
+
+            Assert.IsTrue(isParsed);
+            Assert.AreEqual(input, actual);
+        }
+
     }
 }


### PR DESCRIPTION
As written in the spec: http://www.webdav.org/specs/rfc4918.html#lock-tokens 
"Clients must not attempt to interpret lock tokens in any way."