### PR TITLE
Only allow the TryParse methods

### DIFF
--- a/DecaTec.WebDav/AbsoluteUri.cs
+++ b/DecaTec.WebDav/AbsoluteUri.cs
@@ -15,22 +15,10 @@ namespace DecaTec.WebDav
         /// <summary>
         /// Constructs an <see cref="AbsoluteUri"/>.
         /// </summary>
-        /// <param name="absoluteUrl">The URL to use.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="absoluteUrl"/> is null.</exception>
-        public AbsoluteUri(string absoluteUrl)
-        {
-            if (!Uri.TryCreate(absoluteUrl, UriKind.Absolute, out Uri absoluteUri))
-                throw new ArgumentException($"Cannot create AbsoluteUri from URL '{absoluteUrl}'");
-
-            this.absoluteUri = absoluteUri;
-        }
-
-        /// <summary>
-        /// Constructs an <see cref="AbsoluteUri"/>.
-        /// </summary>
         /// <param name="absoluteUri">The <see cref="Uri"/> to use.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="absoluteUri"/> is null.</exception>
-        public AbsoluteUri(Uri absoluteUri)
+        /// <remarks>Use the <see cref="TryParse"/> factory method to correctly construct an <see cref="AbsoluteUri"/>.</remarks>
+        internal AbsoluteUri(Uri absoluteUri)
         {
             if (absoluteUri == null || !absoluteUri.IsAbsoluteUri)
                 throw new ArgumentException($"Cannot create AbsoluteUri from Uri '{absoluteUri}'");

--- a/DecaTec.WebDav/CodedUrl.cs
+++ b/DecaTec.WebDav/CodedUrl.cs
@@ -23,33 +23,20 @@ namespace DecaTec.WebDav
         private const char CodedUrlPostfix = '>';
 
         /// <summary>
-        /// Constructs a Coded-URL based on the <paramref name="absoluteUrl"/> string.
-        /// See <see href="https://tools.ietf.org/html/rfc4918#section-10.1"/> for the Coded-URL definition.
-        /// </summary>
-        /// <param name="absoluteUrl">The lock token in absolute-URI format (as string).</param>
-        public CodedUrl(string absoluteUrl)
-        {
-            if (!TryParse(absoluteUrl, out var codedUrl))
-                throw new ArgumentException($"Cannot create CodedUrl from URL '{absoluteUrl}'");
-
-            AbsoluteUri = codedUrl.AbsoluteUri;
-        }
-
-        /// <summary>
         /// Constructs a Coded-URL based on the <paramref name="absoluteUri"/>.
         /// See <see href="https://tools.ietf.org/html/rfc4918#section-10.1"/> for the Coded-URL definition.
         /// </summary>
         /// <param name="absoluteUri">The lock token in absolute-URI format.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="absoluteUri"/> is null.</exception>
-        public CodedUrl(AbsoluteUri absoluteUri)
+        internal CodedUrl(AbsoluteUri absoluteUri)
         {
             AbsoluteUri = absoluteUri ?? throw new ArgumentNullException(nameof(absoluteUri));
         }
 
         /// <summary>
-        /// Gets the string representation of this CodedUrl.
+        /// Gets the string representation of this <see cref="CodedUrl"/>.
         /// </summary>
-        /// <returns>The string representation of this CodedUrl.</returns>
+        /// <returns>The string representation of this <see cref="CodedUrl"/>.</returns>
         public override string ToString() => $"{CodedUrlPrefix}{AbsoluteUri}{CodedUrlPostfix}";
 
         /// <summary>

--- a/DecaTec.WebDav/LockToken.cs
+++ b/DecaTec.WebDav/LockToken.cs
@@ -9,32 +9,6 @@ namespace DecaTec.WebDav
     public class LockToken
     {
         /// <summary>
-        /// Constructs a <see cref="LockToken"/> based on the <paramref name="lockToken"/>.
-        /// </summary>
-        /// <param name="lockToken">The lock token as string.</param>
-        /// <remarks>Use the strong-typed constructors to create a new <see cref="LockToken"/>.</remarks>
-        public LockToken(string lockToken)
-        {
-            if (string.IsNullOrEmpty(lockToken))
-                throw new ArgumentException($"The {nameof(lockToken)} cannot be null");
-
-            if (AbsoluteUri.TryParse(lockToken, out var absoluteUri))
-            {
-                AbsoluteUri = absoluteUri;
-                var codedUrl = new CodedUrl(absoluteUri);
-                LockTokenHeaderFormat = codedUrl;
-                IfHeaderNoTagListFormat = new NoTagList(codedUrl);
-            }
-            else if (CodedUrl.TryParse(lockToken, out var codedUrl))
-            {
-                LockTokenHeaderFormat = codedUrl;
-                IfHeaderNoTagListFormat = new NoTagList(codedUrl);
-            }
-            else
-                IfHeaderNoTagListFormat = new NoTagList(lockToken);
-        }
-
-        /// <summary>
         /// Constructs a <see cref="LockToken"/> based on the <paramref name="absoluteUri"/>.
         /// </summary>
         /// <param name="absoluteUri">The lock token in absolute-URI format as defined in https://tools.ietf.org/html/rfc3986#section-4.3.</param>

--- a/DecaTec.WebDav/NoTagList.cs
+++ b/DecaTec.WebDav/NoTagList.cs
@@ -27,30 +27,17 @@ namespace DecaTec.WebDav
         /// Constructs a No Tag List based on the <paramref name="codedUrl"/>.
         /// See <see href="https://tools.ietf.org/html/rfc4918#section-10.4.2"/> for the No Tag List definition.
         /// </summary>
-        /// <param name="codedUrl">The coded-URL for this No-Tag list (as string).</param>
-        public NoTagList(string codedUrl)
-        {
-            if (!TryParse(codedUrl, out var noTagList))
-                throw new ArgumentException($"Cannot create NoTagList from URL '{codedUrl}'");
-
-            CodedUrl = noTagList.CodedUrl;
-        }
-
-        /// <summary>
-        /// Constructs a No Tag List based on the <paramref name="codedUrl"/>.
-        /// See <see href="https://tools.ietf.org/html/rfc4918#section-10.4.2"/> for the No Tag List definition.
-        /// </summary>
         /// <param name="codedUrl">The coded-URL for this No-Tag list.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="codedUrl"/> is null.</exception>
-        public NoTagList(CodedUrl codedUrl)
+        internal NoTagList(CodedUrl codedUrl)
         {
             CodedUrl = codedUrl ?? throw new ArgumentNullException(nameof(codedUrl));
         }
 
         /// <summary>
-        /// Gets the string representation of this NoTagList.
+        /// Gets the string representation of this <see cref="NoTagList"/>.
         /// </summary>
-        /// <returns>The string representation of this NoTagList.</returns>
+        /// <returns>The string representation of this <see cref="NoTagList"/>.</returns>
         public override string ToString() => $"{NoTagListPrefix}{CodedUrl}{NoTagListPostfix}";
 
         /// <summary>

--- a/UnitTests/DecaTec.WebDav.UnitTest/UnitTestAbsoluteUri.cs
+++ b/UnitTests/DecaTec.WebDav.UnitTest/UnitTestAbsoluteUri.cs
@@ -7,58 +7,23 @@ namespace DecaTec.WebDav.UnitTest
     public class UnitTestAbsoluteUri
     {
         [TestMethod]
-        public void UT_AbsoluteUri_Consctuct_FromAbsoluteUri()
-        {
-            var uri = new Uri("http://127.0.0.1/", UriKind.Absolute);
-            var absoluteUri = new AbsoluteUri(uri);
-
-            Assert.AreEqual(uri.ToString(), absoluteUri.ToString());
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void UT_AbsoluteUri_Consctuct_FromRelativeUri_ShouldThrowArgumentException()
-        {
-            var uri = new Uri("/test", UriKind.Relative);
-            var absoluteUri = new AbsoluteUri(uri);
-        }
-
-        [TestMethod]
-        public void UT_AbsoluteUri_Consctuct_FromAbsoluteUrl()
+        public void UT_AbsoluteUri_TryParse_FromAbsoluteUrl()
         {
             var url = "http://127.0.0.1/";
-            var absoluteUri = new AbsoluteUri(url);
+            var isParsed = AbsoluteUri.TryParse(url, out var absoluteUri);
 
+            Assert.IsTrue(isParsed);
             Assert.AreEqual(url, absoluteUri.ToString());
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void UT_AbsoluteUri_Consctuct_FromRelativeUrl_ShouldThrowArgumentException()
+        public void UT_AbsoluteUri_TryParse_FromRelativeUrl()
         {
             var url = "/test";
-            var absoluteUri = new AbsoluteUri(url);
+            var isParsed = AbsoluteUri.TryParse(url, out var absoluteUri);
 
-            Assert.AreEqual(url, absoluteUri.ToString());
-        }
-
-        [TestMethod]
-        public void UT_AbsoluteUri_TryParse_FromAbsoluteUri()
-        {
-            var url = "http://127.0.0.1/";
-            var result = AbsoluteUri.TryParse(url, out var absoluteUri);
-
-            Assert.IsTrue(result);
-            Assert.AreEqual(url, absoluteUri.ToString());
-        }
-
-        [TestMethod]
-        public void UT_AbsoluteUri_TryParse_FromRelativeUri()
-        {
-            var url = "/test";
-            var result = AbsoluteUri.TryParse(url, out var absoluteUri);
-
-            Assert.IsFalse(result);
+            Assert.IsFalse(isParsed);
+            Assert.IsNull(absoluteUri);
         }
     }
 }

--- a/UnitTests/DecaTec.WebDav.UnitTest/UnitTestCodedUrl.cs
+++ b/UnitTests/DecaTec.WebDav.UnitTest/UnitTestCodedUrl.cs
@@ -7,30 +7,6 @@ namespace DecaTec.WebDav.UnitTest
     public class UnitTestCodedUrl
     {
         [TestMethod]
-        public void UT_CodedUrl_Construct_ValidCodedUrlFormat()
-        {
-            var expectedString = "<urn:uuid:my-lock-token>";
-            var codedUrl = new CodedUrl(expectedString);
-
-            Assert.IsNotNull(codedUrl);
-            Assert.AreEqual(expectedString, codedUrl.ToString());
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void UT_CodedUrl_Construct_InvalidCodedUrlFormatAbsoluteUri_ShouldThrowArgumentException()
-        {
-            var codedUrl = new CodedUrl("urn:uuid:my-lock-token");
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void UT_CodedUrl_Construct_InvalidCodedUrlFormatParentheses_ShouldThrowArgumentException()
-        {
-            var codedUrl = new CodedUrl("(urn:uuid:my-lock-token)");
-        }
-
-        [TestMethod]
         public void UT_CodedUrl_TryParse_ValidCodedUrlFormat()
         {
             var expectedString = "<urn:uuid:my-lock-token>";

--- a/UnitTests/DecaTec.WebDav.UnitTest/UnitTestLockToken.cs
+++ b/UnitTests/DecaTec.WebDav.UnitTest/UnitTestLockToken.cs
@@ -8,21 +8,10 @@ namespace DecaTec.WebDav.UnitTest
         [TestMethod]
         public void UT_LockToken_IfHeaderNoTagListFormat_IfHeaderWithoutBrackets()
         {
-            var parseResult = AbsoluteUri.TryParse("urn:uuid:my-lock-token", out var absoluteUri);
+            var parseResult = AbsoluteUri.TryParse("urn:uuid:my-lock-token", out var parsedUri);
 
-            var lockToken = new LockToken(absoluteUri);
-            var noTagList = lockToken.IfHeaderNoTagListFormat;
+            var lockToken = new LockToken(parsedUri);
 
-            Assert.AreEqual("(<urn:uuid:my-lock-token>)", noTagList.ToString());
-            Assert.IsTrue(parseResult);
-        }
-
-        [TestMethod]
-        public void UT_LockToken_Construct_IfHeaderWithoutBracketsWithString()
-        {
-            var lockTokenString = "urn:uuid:my-lock-token";
-
-            var lockToken = new LockToken(lockTokenString);
             var absoluteUri = lockToken.AbsoluteUri;
             var lockTokenHeaderFormat = lockToken.LockTokenHeaderFormat;
             var noTagList = lockToken.IfHeaderNoTagListFormat;
@@ -30,6 +19,7 @@ namespace DecaTec.WebDav.UnitTest
             Assert.AreEqual("urn:uuid:my-lock-token", absoluteUri.ToString());
             Assert.AreEqual("<urn:uuid:my-lock-token>", lockTokenHeaderFormat.ToString());
             Assert.AreEqual("(<urn:uuid:my-lock-token>)", noTagList.ToString());
+            Assert.IsTrue(parseResult);
         }
 
         [TestMethod]
@@ -38,52 +28,30 @@ namespace DecaTec.WebDav.UnitTest
             var parseResult = CodedUrl.TryParse("<urn:uuid:my-lock-token>", out var codedUrl);
 
             var lockToken = new LockToken(codedUrl.AbsoluteUri);
-            var noTagList = lockToken.IfHeaderNoTagListFormat;
-
-            Assert.AreEqual("(<urn:uuid:my-lock-token>)", noTagList.ToString());
-            Assert.IsTrue(parseResult);
-        }
-
-        [TestMethod]
-        public void UT_LockToken_Construct_IfHeaderWithBracketsWithString()
-        {
-            var lockTokenString = "<urn:uuid:my-lock-token>";
-
-            var lockToken = new LockToken(lockTokenString);
             var absoluteUri = lockToken.AbsoluteUri;
-            var noTagList = lockToken.IfHeaderNoTagListFormat;
             var lockTokenHeaderFormat = lockToken.LockTokenHeaderFormat;
+            var noTagList = lockToken.IfHeaderNoTagListFormat;
 
-            Assert.IsNull(absoluteUri);
+            Assert.AreEqual("urn:uuid:my-lock-token", absoluteUri.ToString());
             Assert.AreEqual("<urn:uuid:my-lock-token>", lockTokenHeaderFormat.ToString());
             Assert.AreEqual("(<urn:uuid:my-lock-token>)", noTagList.ToString());
+            Assert.IsTrue(parseResult);
         }
 
         [TestMethod]
         public void UT_LockToken_LockTokenHeaderFormat_LockTokenHeaderWithoutBrackets()
         {
-            var parseResult = AbsoluteUri.TryParse("urn:uuid:my-lock-token", out var absoluteUri);
+            var parseResult = AbsoluteUri.TryParse("urn:uuid:my-lock-token", out var parsedUri);
 
-            var lockToken = new LockToken(absoluteUri);
-            var codedUrl = lockToken.LockTokenHeaderFormat;
-
-            Assert.AreEqual("<urn:uuid:my-lock-token>", codedUrl.ToString());
-            Assert.IsTrue(parseResult);
-        }
-
-        [TestMethod]
-        public void UT_LockToken_Construct_LockTokenHeaderWithoutBracketsWithString()
-        {
-            var lockTokenString = "urn:uuid:my-lock-token";
-
-            var lockToken = new LockToken(lockTokenString);
+            var lockToken = new LockToken(parsedUri);
             var absoluteUri = lockToken.AbsoluteUri;
-            var codedUrl = lockToken.LockTokenHeaderFormat;
-            var ifHeaderNoTagListFormat = lockToken.IfHeaderNoTagListFormat;
+            var lockTokenHeaderFormat = lockToken.LockTokenHeaderFormat;
+            var noTagList = lockToken.IfHeaderNoTagListFormat;
 
             Assert.AreEqual("urn:uuid:my-lock-token", absoluteUri.ToString());
-            Assert.AreEqual("<urn:uuid:my-lock-token>", codedUrl.ToString());
-            Assert.AreEqual("(<urn:uuid:my-lock-token>)", ifHeaderNoTagListFormat.ToString());
+            Assert.AreEqual("<urn:uuid:my-lock-token>", lockTokenHeaderFormat.ToString());
+            Assert.AreEqual("(<urn:uuid:my-lock-token>)", noTagList.ToString());
+            Assert.IsTrue(parseResult);
         }
 
         [TestMethod]
@@ -92,25 +60,15 @@ namespace DecaTec.WebDav.UnitTest
             var parseResult = CodedUrl.TryParse("<urn:uuid:my-lock-token>", out var codedUrl);
 
             var lockToken = new LockToken(codedUrl.AbsoluteUri);
-            var lockTokenHeaderFormat = lockToken.LockTokenHeaderFormat;
 
-            Assert.AreEqual("<urn:uuid:my-lock-token>", lockTokenHeaderFormat.ToString());
-            Assert.IsTrue(parseResult);
-        }
-
-        [TestMethod]
-        public void UT_LockToken_Construct_LockTokenHeaderWithBracketsWithString()
-        {
-            var lockTokenString = "<urn:uuid:my-lock-token>";
-
-            var lockToken = new LockToken(lockTokenString);
             var absoluteUri = lockToken.AbsoluteUri;
             var lockTokenHeaderFormat = lockToken.LockTokenHeaderFormat;
-            var ifHeaderNoTagListFormat = lockToken.IfHeaderNoTagListFormat;
+            var noTagList = lockToken.IfHeaderNoTagListFormat;
 
-            Assert.IsNull(absoluteUri);
+            Assert.AreEqual("urn:uuid:my-lock-token", absoluteUri.ToString());
             Assert.AreEqual("<urn:uuid:my-lock-token>", lockTokenHeaderFormat.ToString());
-            Assert.AreEqual("(<urn:uuid:my-lock-token>)", ifHeaderNoTagListFormat.ToString());
+            Assert.AreEqual("(<urn:uuid:my-lock-token>)", noTagList.ToString());
+            Assert.IsTrue(parseResult);
         }
 
         [TestMethod]
@@ -118,28 +76,17 @@ namespace DecaTec.WebDav.UnitTest
         {
             var lockTokenString = "(<urn:uuid:my-lock-token>)";
 
-            var parseResult = NoTagList.TryParse(lockTokenString, out var noTagList);
+            var parseResult = NoTagList.TryParse(lockTokenString, out var parsedNoTagList);
+            var lockToken = new LockToken(parsedNoTagList.CodedUrl.AbsoluteUri);
 
-            var lockToken = new LockToken(noTagList.CodedUrl.AbsoluteUri);
-            var lockTokenHeaderFormat = lockToken.LockTokenHeaderFormat;
-
-            Assert.AreEqual("<urn:uuid:my-lock-token>", lockTokenHeaderFormat.ToString());
-            Assert.IsTrue(parseResult);
-        }
-
-        [TestMethod]
-        public void UT_LockToken_Construct_LockTokenHeaderFormat_LockTokenHeaderWithBothBracketsWithString()
-        {
-            var lockTokenString = "(<urn:uuid:my-lock-token>)";
-
-            var lockToken = new LockToken(lockTokenString);
             var absoluteUri = lockToken.AbsoluteUri;
             var lockTokenHeaderFormat = lockToken.LockTokenHeaderFormat;
-            var ifHeaderNoTagListFormat = lockToken.IfHeaderNoTagListFormat;
+            var noTagList = lockToken.IfHeaderNoTagListFormat;
 
-            Assert.IsNull(absoluteUri);
-            Assert.IsNull(lockTokenHeaderFormat);
-            Assert.AreEqual(lockTokenString, ifHeaderNoTagListFormat.ToString());
+            Assert.AreEqual("urn:uuid:my-lock-token", absoluteUri.ToString());
+            Assert.AreEqual("<urn:uuid:my-lock-token>", lockTokenHeaderFormat.ToString());
+            Assert.AreEqual("(<urn:uuid:my-lock-token>)", noTagList.ToString());
+            Assert.IsTrue(parseResult);
         }
     }
 }

--- a/UnitTests/DecaTec.WebDav.UnitTest/UnitTestNoTagList.cs
+++ b/UnitTests/DecaTec.WebDav.UnitTest/UnitTestNoTagList.cs
@@ -7,37 +7,6 @@ namespace DecaTec.WebDav.UnitTest
     public class UnitTestNoTagList
     {
         [TestMethod]
-        public void UT_NoTagList_Construct_ValidNoTagListFormat()
-        {
-            var expectedString = "(<urn:uuid:my-lock-token>)";
-            var noTagList = new NoTagList(expectedString);
-
-            Assert.AreEqual(expectedString, noTagList.ToString());
-            Assert.IsNotNull(noTagList);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void UT_NoTagList_Construct_InvalidNoTagListFormatAbsoluteURI_ShouldThrowArgumentException()
-        {
-            var noTagList = new NoTagList("urn:uuid:my-lock-token");
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void UT_NoTagList_Construct_InvalidNoTagListFormatParentheses_ShouldThrowArgumentException()
-        {
-            var noTagList = new NoTagList("(urn:uuid:my-lock-token)");
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public void UT_NoTagList_Construct_InvalidNoTagListFormatBrackets_ShouldThrowArgumentException()
-        {
-            var noTagList = new NoTagList("<urn:uuid:my-lock-token>");
-        }
-
-        [TestMethod]
         public void UT_NoTagList_TryParse_ValidNoTagListFormat()
         {
             var expectedString = "(<urn:uuid:my-lock-token>)";

--- a/UnitTests/DecaTec.WebDav.UnitTest/UnitTestWebDavClient.cs
+++ b/UnitTests/DecaTec.WebDav.UnitTest/UnitTestWebDavClient.cs
@@ -678,6 +678,7 @@ namespace DecaTec.WebDav.UnitTest
         {
             var testFileToUnlock = UriHelper.CombineUrl(WebDavRootFolder, TestFile, true);
             var lockTokenString = "<opaquelocktoken:cb2b7d6d-98ea-47cf-b569-5b98126b8f13.6df801d2b41b3b6e>";
+            CodedUrl.TryParse(lockTokenString, out var codedUrl);
 
             var mockHandler = new MockHttpMessageHandler();
 
@@ -689,7 +690,7 @@ namespace DecaTec.WebDav.UnitTest
             mockHandler.When(WebDavMethod.Unlock, testFileToUnlock).WithHeaders(requestHeaders).Respond(HttpStatusCode.NoContent);
 
             var client = CreateWebDavClient(mockHandler);
-            var lockToken = new LockToken(lockTokenString);
+            var lockToken = new LockToken(codedUrl.AbsoluteUri);
             var response = client.UnlockAsync(testFileToUnlock, lockToken).Result;
 
             Assert.IsTrue(response.IsSuccessStatusCode);

--- a/UnitTests/DecaTec.WebDav.UnitTest/UnitTestWebDavSession.cs
+++ b/UnitTests/DecaTec.WebDav.UnitTest/UnitTestWebDavSession.cs
@@ -435,7 +435,6 @@ namespace DecaTec.WebDav.UnitTest
             var success = session.LockAsync(TestFile).Result;
 
             Assert.IsTrue(success);
-            var lockToken = new LockToken(lockTokenString);
             success = session.UnlockAsync(testFileToLock).Result;
 
             Assert.IsTrue(success);


### PR DESCRIPTION
In AbsoluteUri, CodedUrl, NoTagList and LockToken. Update the unittests accordingly.

This allows the specification not to be bypassed. 

It might be an idea to create 2 extra convenience constructors in LockToken, accepting a NoTagList or CodedUrl. However, we did not see a need for this right now.