### PR TITLE
Add GetActiveLockFromWebDavResponseMessage to the WebDavHelper

### DIFF
--- a/DecaTec.WebDav/Tools/WebDavHelper.cs
+++ b/DecaTec.WebDav/Tools/WebDavHelper.cs
@@ -19,6 +19,39 @@ namespace DecaTec.WebDav.Tools
     public static class WebDavHelper
     {
         /// <summary>
+        /// Gets the <see cref="ActiveLock"/> from a <see cref="WebDavResponseMessage"/>.
+        /// </summary>
+        /// <param name="responseMessage">The <see cref="WebDavResponseMessage"/> whose <see cref="ActiveLock"/> should be retrieved.</param>
+        /// <returns>The <see cref="ActiveLock"/> of the <see cref="WebDavResponseMessage"/> or null if the <see cref="WebDavResponseMessage"/> does not contain a lock token.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="responseMessage"/> is null.</exception>
+        public static ActiveLock GetActiveLockFromWebDavResponseMessage(WebDavResponseMessage responseMessage)
+        {
+            if (responseMessage == null)
+                throw new ArgumentNullException(nameof(responseMessage));
+
+            var prop = WebDavResponseContentParser.ParsePropResponseContentAsync(responseMessage.Content).Result;
+            var activeLock = prop.LockDiscovery?.ActiveLock.FirstOrDefault();
+
+            if (activeLock == null)
+                return null;
+
+            // If lock token was not be found in the response content, it should be submitted by response header.
+            if (activeLock.LockToken == null)
+                // Try to get lock token from response header.
+                if (responseMessage.Headers.TryGetValues(WebDavRequestHeader.LockToken, out IEnumerable<string> lockTokenHeaderValues))
+                {
+                    // We assume only one Lock-Token header is sent, based on the spec: https://tools.ietf.org/html/rfc4918#section-9.10.1
+                    var lockTokenHeaderValue = lockTokenHeaderValues.FirstOrDefault();
+
+                    // Make sure the lockTokenHeaderValue is valid according to spec (https://tools.ietf.org/html/rfc4918#section-10.5).
+                    if (lockTokenHeaderValue != null && CodedUrl.TryParse(lockTokenHeaderValue, out var _))
+                        activeLock.LockToken = new WebDavLockToken { Href = lockTokenHeaderValue };
+                }
+
+            return activeLock;
+        }
+
+        /// <summary>
         /// Gets a UTF-8 encoded string by serializing the object specified.
         /// </summary>
         /// <param name="xmlSerializer">The <see cref="XmlSerializer"/> to use.</param>


### PR DESCRIPTION
We required the owner besides the lock token, so we need the entire `ActiveLock`.

The `GetLockTokenFromWebDavResponseMessage` only returns the lock token so we couldn't use that one. 