### PR TITLE
Throws exception in case error response WebSession

### DIFF
--- a/DecaTec.WebDav/DecaTec.WebDav.csproj
+++ b/DecaTec.WebDav/DecaTec.WebDav.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <PackageId>PortableWebDavLibrary</PackageId>
-    <Version>1.1.3.1</Version>
+    <Version>1.1.4.0</Version>
     <Authors>DecaTec</Authors>
     <Company>DecaTec</Company>
     <Product>PortableWebDavLibrary</Product>
@@ -16,8 +16,8 @@
     <PackageTags>WebDAV, portable, NETStandard, NETCore, UWP, dotnet, portable-webdav-library, Xamarin, Mono, multiplatform</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageReleaseNotes>Full documentation with changelog is available at https://decatec.de/ext/PortableWebDAVLibrary/Doc</PackageReleaseNotes>
-    <AssemblyVersion>1.1.3.1</AssemblyVersion>
-    <FileVersion>1.1.3.1</FileVersion>
+    <AssemblyVersion>1.1.4.0</AssemblyVersion>
+    <FileVersion>1.1.4.0</FileVersion>
   </PropertyGroup>
 
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">

--- a/DecaTec.WebDav/DecaTec.WebDav.csproj
+++ b/DecaTec.WebDav/DecaTec.WebDav.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>

--- a/DecaTec.WebDav/DecaTec.WebDav.csproj
+++ b/DecaTec.WebDav/DecaTec.WebDav.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.1</TargetFramework>
     <PackageId>PortableWebDavLibrary</PackageId>
-    <Version>1.1.3.0</Version>
+    <Version>1.1.3.1</Version>
     <Authors>DecaTec</Authors>
     <Company>DecaTec</Company>
     <Product>PortableWebDavLibrary</Product>
@@ -16,8 +16,8 @@
     <PackageTags>WebDAV, portable, NETStandard, NETCore, UWP, dotnet, portable-webdav-library, Xamarin, Mono, multiplatform</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageReleaseNotes>Full documentation with changelog is available at https://decatec.de/ext/PortableWebDAVLibrary/Doc</PackageReleaseNotes>
-    <AssemblyVersion>1.1.3.0</AssemblyVersion>
-    <FileVersion>1.1.3.0</FileVersion>
+    <AssemblyVersion>1.1.3.1</AssemblyVersion>
+    <FileVersion>1.1.3.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/DecaTec.WebDav/DecaTec.WebDav.csproj
+++ b/DecaTec.WebDav/DecaTec.WebDav.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>net46;netstandard1.1;netstandard2.0</TargetFrameworks>
     <PackageId>PortableWebDavLibrary</PackageId>
     <Version>1.1.3.1</Version>
     <Authors>DecaTec</Authors>
@@ -20,13 +20,19 @@
     <FileVersion>1.1.3.1</FileVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\Build\Debug\</OutputPath>
+  <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
+    <ItemGroup>
+      <DocFile Include="bin\$(Configuration)\$(TargetFramework)\*.xml" />
+    </ItemGroup>
+    <Copy SourceFiles="@(DocFile)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
+  </Target>
+
+  <PropertyGroup>
+    <OutputPath>..\Build\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\Build\Release\</OutputPath>
-    <DocumentationFile>..\Build\Release\netstandard1.1\DecaTec.WebDav.XML</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DocumentationFile>..\Build\$(Configuration)\$(TargetFramework)\DecaTec.WebDav.XML</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DecaTec.WebDav/WebDavClient.cs
+++ b/DecaTec.WebDav/WebDavClient.cs
@@ -42,14 +42,14 @@ namespace DecaTec.WebDav
     ///
     /// // Create a PropFind object with represents a so called 'allprop' request.
     /// var pf = PropFind.CreatePropFindAllProp();
-    /// var response = webDavClient.PropFindAsync(webDavServerUrl + @"/MyFolder/", WebDavDepthHeaderValue.Infinity, pf);
+    /// var response = await webDavClient.PropFindAsync(webDavServerUrl + @"/MyFolder/", WebDavDepthHeaderValue.Infinity, pf);
     ///
     /// // You could also use an XML string directly for use with the WebDavClient.
     /// //var xmlString = "&lt;?xml version=\&quot;1.0\&quot; encoding=\&quot;utf-8\&quot;?&gt;&lt;D:propfind xmlns:D=\&quot;DAV:\&quot;&gt;&lt;D:allprop /&gt;&lt;/D:propfind&gt;";
-    /// //var response = webDavClient.PropFindAsync(webDavServerUrl + @"/MyFolder/", WebDavDepthHeaderValue.Infinity, xmlString);
+    /// //var response = await webDavClient.PropFindAsync(webDavServerUrl + @"/MyFolder/", WebDavDepthHeaderValue.Infinity, xmlString);
     ///
-    /// // Use the WebDavResponseContentParser to parse the response message and get a MultiStatus instance (this is also an method).
-    /// var multistatus = WebDavResponseContentParser.ParseMultistatusResponseContentAsync(response.Content);
+    /// // Use the WebDavResponseContentParser to parse the response message and get a MultiStatus instance (this is also an async method).
+    /// var multistatus = await WebDavResponseContentParser.ParseMultistatusResponseContentAsync(response.Content);
     ///
     /// // Now you can use the MultiStatus object to get access to the items properties.
     /// foreach (var responseItem in multistatus.Response)
@@ -84,7 +84,7 @@ namespace DecaTec.WebDav
     /// // Other information about the owner (e.g. mixed content) can also be specified. Use the property OwnerRaw in this case.
     ///
     /// // Lock the desired folder by specifying a WebDavTimeOutHeaderValue (in this example, the timeout should be infinite), a value for depth and the LockInfo.
-    /// var lockResult = webDavClient.LockAsync(@"http://www.myserver.com/webdav/MyFolder/", WebDavTimeoutHeaderValue.CreateInfiniteWebDavTimeout(), WebDavDepthHeaderValue.Infinity, lockInfo);
+    /// var lockResult = await webDavClient.LockAsync(@"http://www.myserver.com/webdav/MyFolder/", WebDavTimeoutHeaderValue.CreateInfiniteWebDavTimeout(), WebDavDepthHeaderValue.Infinity, lockInfo);
     ///            
     /// // On successful locking, a lock token will be returned by the WebDAV server.
     /// // We have to save this lock token in order to use it on operations which affect a locked folder.
@@ -93,14 +93,14 @@ namespace DecaTec.WebDav
     /// // Now create a new folder in the locked location.
     /// // Notice that the LockToken has to be specified as a locked folder is affected by this operation.
     /// // If the LockToken would not be specified, the operation will fail!
-    /// webDavClient.MkcolAsync(@"http://www.myserver.com/webdav/MyFolder/NewFolder/", lockToken);
+    /// await webDavClient.MkcolAsync(@"http://www.myserver.com/webdav/MyFolder/NewFolder/", lockToken);
     ///
     /// // Delete the folder again.
-    /// webDavClient.DeleteAsync(@"http://www.myserver.com/webdav/MyFolder/NewFolder/", lockToken);
+    /// await webDavClient.DeleteAsync(@"http://www.myserver.com/webdav/MyFolder/NewFolder/", lockToken);
     ///
     /// // Unlock the locked folder.
     /// // Notice that the URL is the same as used with the lock method (see above).
-    /// webDavClient.UnlockAsync(@"http://www.myserver.com/webdav/MyFolder/", lockToken);
+    /// await webDavClient.UnlockAsync(@"http://www.myserver.com/webdav/MyFolder/", lockToken);
     /// </code>
     /// </example>
     /// </remarks>

--- a/DecaTec.WebDav/WebDavClient.cs
+++ b/DecaTec.WebDav/WebDavClient.cs
@@ -42,14 +42,14 @@ namespace DecaTec.WebDav
     ///
     /// // Create a PropFind object with represents a so called 'allprop' request.
     /// var pf = PropFind.CreatePropFindAllProp();
-    /// var response = await webDavClient.PropFindAsync(webDavServerUrl + @"/MyFolder/", WebDavDepthHeaderValue.Infinity, pf);
+    /// var response = webDavClient.PropFindAsync(webDavServerUrl + @"/MyFolder/", WebDavDepthHeaderValue.Infinity, pf);
     ///
     /// // You could also use an XML string directly for use with the WebDavClient.
     /// //var xmlString = "&lt;?xml version=\&quot;1.0\&quot; encoding=\&quot;utf-8\&quot;?&gt;&lt;D:propfind xmlns:D=\&quot;DAV:\&quot;&gt;&lt;D:allprop /&gt;&lt;/D:propfind&gt;";
-    /// //var response = await webDavClient.PropFindAsync(webDavServerUrl + @"/MyFolder/", WebDavDepthHeaderValue.Infinity, xmlString);
+    /// //var response = webDavClient.PropFindAsync(webDavServerUrl + @"/MyFolder/", WebDavDepthHeaderValue.Infinity, xmlString);
     ///
-    /// // Use the WebDavResponseContentParser to parse the response message and get a MultiStatus instance (this is also an async method).
-    /// var multistatus = await WebDavResponseContentParser.ParseMultistatusResponseContentAsync(response.Content);
+    /// // Use the WebDavResponseContentParser to parse the response message and get a MultiStatus instance (this is also an method).
+    /// var multistatus = WebDavResponseContentParser.ParseMultistatusResponseContentAsync(response.Content);
     ///
     /// // Now you can use the MultiStatus object to get access to the items properties.
     /// foreach (var responseItem in multistatus.Response)
@@ -84,7 +84,7 @@ namespace DecaTec.WebDav
     /// // Other information about the owner (e.g. mixed content) can also be specified. Use the property OwnerRaw in this case.
     ///
     /// // Lock the desired folder by specifying a WebDavTimeOutHeaderValue (in this example, the timeout should be infinite), a value for depth and the LockInfo.
-    /// var lockResult = await webDavClient.LockAsync(@"http://www.myserver.com/webdav/MyFolder/", WebDavTimeoutHeaderValue.CreateInfiniteWebDavTimeout(), WebDavDepthHeaderValue.Infinity, lockInfo);
+    /// var lockResult = webDavClient.LockAsync(@"http://www.myserver.com/webdav/MyFolder/", WebDavTimeoutHeaderValue.CreateInfiniteWebDavTimeout(), WebDavDepthHeaderValue.Infinity, lockInfo);
     ///            
     /// // On successful locking, a lock token will be returned by the WebDAV server.
     /// // We have to save this lock token in order to use it on operations which affect a locked folder.
@@ -93,14 +93,14 @@ namespace DecaTec.WebDav
     /// // Now create a new folder in the locked location.
     /// // Notice that the LockToken has to be specified as a locked folder is affected by this operation.
     /// // If the LockToken would not be specified, the operation will fail!
-    /// await webDavClient.MkcolAsync(@"http://www.myserver.com/webdav/MyFolder/NewFolder/", lockToken);
+    /// webDavClient.MkcolAsync(@"http://www.myserver.com/webdav/MyFolder/NewFolder/", lockToken);
     ///
     /// // Delete the folder again.
-    /// await webDavClient.DeleteAsync(@"http://www.myserver.com/webdav/MyFolder/NewFolder/", lockToken);
+    /// webDavClient.DeleteAsync(@"http://www.myserver.com/webdav/MyFolder/NewFolder/", lockToken);
     ///
     /// // Unlock the locked folder.
     /// // Notice that the URL is the same as used with the lock method (see above).
-    /// await webDavClient.UnlockAsync(@"http://www.myserver.com/webdav/MyFolder/", lockToken);
+    /// webDavClient.UnlockAsync(@"http://www.myserver.com/webdav/MyFolder/", lockToken);
     /// </code>
     /// </example>
     /// </remarks>
@@ -213,9 +213,9 @@ namespace DecaTec.WebDav
         /// <param name="sourceUrl">The source URL.</param>
         /// <param name="destinationUrl">The destination URL.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> CopyAsync(string sourceUrl, string destinationUrl)
+        public Task<WebDavResponseMessage> CopyAsync(string sourceUrl, string destinationUrl)
         {
-            return await CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false, WebDavDepthHeaderValue.Infinity, null);
+            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false, WebDavDepthHeaderValue.Infinity, null);
         }
 
         /// <summary>
@@ -224,9 +224,9 @@ namespace DecaTec.WebDav
         /// <param name="sourceUri">The source <see cref="Uri"/>.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/> .</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> CopyAsync(Uri sourceUri, Uri destinationUri)
+        public Task<WebDavResponseMessage> CopyAsync(Uri sourceUri, Uri destinationUri)
         {
-            return await CopyAsync(sourceUri, destinationUri, false, WebDavDepthHeaderValue.Infinity, null);
+            return CopyAsync(sourceUri, destinationUri, false, WebDavDepthHeaderValue.Infinity, null);
         }
 
         /// <summary>
@@ -236,9 +236,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUrl">The destination URL.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite)
+        public Task<WebDavResponseMessage> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite)
         {
-            return await CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, WebDavDepthHeaderValue.Infinity, null);
+            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, WebDavDepthHeaderValue.Infinity, null);
         }
 
         /// <summary>
@@ -248,9 +248,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite)
+        public Task<WebDavResponseMessage> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite)
         {
-            return await CopyAsync(sourceUri, destinationUri, overwrite, WebDavDepthHeaderValue.Infinity, null);
+            return CopyAsync(sourceUri, destinationUri, overwrite, WebDavDepthHeaderValue.Infinity, null);
         }
 
         /// <summary>
@@ -261,9 +261,9 @@ namespace DecaTec.WebDav
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> for the copy command. On collections, depth must be '0' or 'infinity'.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite, WebDavDepthHeaderValue depth)
+        public Task<WebDavResponseMessage> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite, WebDavDepthHeaderValue depth)
         {
-            return await CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, depth, null);
+            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, depth, null);
         }
 
         /// <summary>
@@ -274,9 +274,9 @@ namespace DecaTec.WebDav
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> for the copy command. On collections, depth must be '0' or 'infinity'.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite, WebDavDepthHeaderValue depth)
+        public Task<WebDavResponseMessage> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite, WebDavDepthHeaderValue depth)
         {
-            return await CopyAsync(sourceUri, destinationUri, overwrite, depth, null);
+            return CopyAsync(sourceUri, destinationUri, overwrite, depth, null);
         }
 
         /// <summary>
@@ -288,9 +288,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> for the copy command. On collections, depth must be '0' or 'infinity'.</param>
         /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite, WebDavDepthHeaderValue depth, LockToken lockTokenDestination)
+        public Task<WebDavResponseMessage> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite, WebDavDepthHeaderValue depth, LockToken lockTokenDestination)
         {
-            return await CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, depth, lockTokenDestination);
+            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, depth, lockTokenDestination);
         }
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> for the copy command. On collections, depth must be '0' or 'infinity'.</param>
         /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite, WebDavDepthHeaderValue depth, LockToken lockTokenDestination)
+        public Task<WebDavResponseMessage> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite, WebDavDepthHeaderValue depth, LockToken lockTokenDestination)
         {
             var requestMethod = new HttpRequestMessage(WebDavMethod.Copy, sourceUri);
             SetHttpVersion(requestMethod);
@@ -324,8 +324,7 @@ namespace DecaTec.WebDav
             if (lockTokenDestination != null)
                 requestMethod.Headers.Add(WebDavRequestHeader.If, lockTokenDestination.IfHeaderNoTagListFormat.ToString());
 
-            var taskHttpResponseMessage = await this.SendAsync(requestMethod);
-            return taskHttpResponseMessage;
+            return this.SendAsync(requestMethod);
         }
 
         #endregion Copy
@@ -337,9 +336,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> DeleteAsync(string requestUrl)
+        public new Task<WebDavResponseMessage> DeleteAsync(string requestUrl)
         {
-            return await DeleteAsync(UriHelper.CreateUriFromUrl(requestUrl), null, CancellationToken.None);
+            return DeleteAsync(UriHelper.CreateUriFromUrl(requestUrl), null, CancellationToken.None);
         }
 
         /// <summary>
@@ -347,9 +346,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> DeleteAsync(Uri requestUri)
+        public new Task<WebDavResponseMessage> DeleteAsync(Uri requestUri)
         {
-            return await DeleteAsync(requestUri, null, CancellationToken.None);
+            return DeleteAsync(requestUri, null, CancellationToken.None);
         }
 
         /// <summary>
@@ -358,9 +357,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> DeleteAsync(string requestUrl, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> DeleteAsync(string requestUrl, CancellationToken cancellationToken)
         {
-            return await DeleteAsync(UriHelper.CreateUriFromUrl(requestUrl), null, cancellationToken);
+            return DeleteAsync(UriHelper.CreateUriFromUrl(requestUrl), null, cancellationToken);
         }
 
         /// <summary>
@@ -369,9 +368,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> DeleteAsync(Uri requestUri, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> DeleteAsync(Uri requestUri, CancellationToken cancellationToken)
         {
-            return await DeleteAsync(requestUri, null, cancellationToken);
+            return DeleteAsync(requestUri, null, cancellationToken);
         }
 
         /// <summary>
@@ -380,9 +379,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> DeleteAsync(string requestUrl, LockToken lockToken)
+        public Task<WebDavResponseMessage> DeleteAsync(string requestUrl, LockToken lockToken)
         {
-            return await DeleteAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, CancellationToken.None);
+            return DeleteAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, CancellationToken.None);
         }
 
         /// <summary>
@@ -391,9 +390,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> DeleteAsync(Uri requestUri, LockToken lockToken)
+        public Task<WebDavResponseMessage> DeleteAsync(Uri requestUri, LockToken lockToken)
         {
-            return await DeleteAsync(requestUri, lockToken, CancellationToken.None);
+            return DeleteAsync(requestUri, lockToken, CancellationToken.None);
         }
 
         /// <summary>
@@ -403,9 +402,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> DeleteAsync(string requestUrl, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> DeleteAsync(string requestUrl, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await DeleteAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, cancellationToken);
+            return DeleteAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, cancellationToken);
         }
 
         /// <summary>
@@ -415,7 +414,7 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> DeleteAsync(Uri requestUri, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> DeleteAsync(Uri requestUri, LockToken lockToken, CancellationToken cancellationToken)
         {
             // On collections: Clients must not use any other value for the Depth header but 'infinity'.
             // A DELETE command without depth header will be treated by the server as if Depth = 'infinity' was used.
@@ -426,8 +425,7 @@ namespace DecaTec.WebDav
             if (lockToken != null)
                 requestMethod.Headers.Add(WebDavRequestHeader.If, lockToken.IfHeaderNoTagListFormat.ToString());
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, HttpCompletionOption.ResponseContentRead, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         #endregion Delete
@@ -443,9 +441,9 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>The <see cref="Stream"/> passed does not get disposed while using this method. It is up to the client to handle disposing of this stream.</remarks>
-        public async Task<WebDavResponseMessage> DownloadFileWithProgressAsync(string url, Stream targetStream, CancellationToken cancellationToken, IProgress<WebDavProgress> progress)
+        public Task<WebDavResponseMessage> DownloadFileWithProgressAsync(string url, Stream targetStream, CancellationToken cancellationToken, IProgress<WebDavProgress> progress)
         {
-            return await this.DownloadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), targetStream, cancellationToken, progress);
+            return this.DownloadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), targetStream, cancellationToken, progress);
         }
 
         /// <summary>
@@ -467,9 +465,11 @@ namespace DecaTec.WebDav
             if (!(httpResponseMessage.Content.Headers.TryGetValues(HttpHeaderNames.ContentLength, out IEnumerable<string> contentLengthHeader) && long.TryParse(contentLengthHeader.FirstOrDefault(), out long totalLength)))
                 totalLength = 0L;
 
-            var stream = new WebDavProgressStreamContent(new ProgressStream(await httpResponseMessage.Content.ReadAsStreamAsync(), cancellationToken), totalLength, progress);
-            await stream.CopyToAsync(targetStream);
-            await targetStream.FlushAsync();
+            using (var stream = new WebDavProgressStreamContent(new ProgressStream(await httpResponseMessage.Content.ReadAsStreamAsync(), cancellationToken), totalLength, progress))
+            {
+                await stream.CopyToAsync(targetStream);
+                await targetStream.FlushAsync();
+            }
 
             // Do not dispose the targetStream here as it passed by the client.
             // It's up to the client to handle this stream an dispose it after use.
@@ -486,9 +486,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> GetAsync(string requestUrl)
+        public new Task<WebDavResponseMessage> GetAsync(string requestUrl)
         {
-            return await GetAsync(UriHelper.CreateUriFromUrl(requestUrl), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return GetAsync(UriHelper.CreateUriFromUrl(requestUrl), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -496,9 +496,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> GetAsync(Uri requestUri)
+        public new Task<WebDavResponseMessage> GetAsync(Uri requestUri)
         {
-            return await GetAsync(requestUri, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return GetAsync(requestUri, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -507,9 +507,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> GetAsync(string requestUrl, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> GetAsync(string requestUrl, CancellationToken cancellationToken)
         {
-            return await GetAsync(UriHelper.CreateUriFromUrl(requestUrl), HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return GetAsync(UriHelper.CreateUriFromUrl(requestUrl), HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -518,9 +518,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> GetAsync(Uri requestUri, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> GetAsync(Uri requestUri, CancellationToken cancellationToken)
         {
-            return await GetAsync(requestUri, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return GetAsync(requestUri, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -529,9 +529,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> GetAsync(string requestUrl, HttpCompletionOption completionOption)
+        public new Task<WebDavResponseMessage> GetAsync(string requestUrl, HttpCompletionOption completionOption)
         {
-            return await GetAsync(UriHelper.CreateUriFromUrl(requestUrl), completionOption, CancellationToken.None);
+            return GetAsync(UriHelper.CreateUriFromUrl(requestUrl), completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -540,9 +540,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> GetAsync(Uri requestUri, HttpCompletionOption completionOption)
+        public new Task<WebDavResponseMessage> GetAsync(Uri requestUri, HttpCompletionOption completionOption)
         {
-            return await GetAsync(requestUri, completionOption, CancellationToken.None);
+            return GetAsync(requestUri, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -552,9 +552,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> GetAsync(string requestUrl, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> GetAsync(string requestUrl, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await GetAsync(UriHelper.CreateUriFromUrl(requestUrl), completionOption, cancellationToken);
+            return GetAsync(UriHelper.CreateUriFromUrl(requestUrl), completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -564,12 +564,11 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/>  value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> GetAsync(Uri requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> GetAsync(Uri requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             var requestMethod = new HttpRequestMessage(HttpMethod.Get, requestUri);
             SetHttpVersion(requestMethod);
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         #endregion Get
@@ -581,9 +580,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> HeadAsync(string requestUrl)
+        public Task<WebDavResponseMessage> HeadAsync(string requestUrl)
         {
-            return await HeadAsync(UriHelper.CreateUriFromUrl(requestUrl), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return HeadAsync(UriHelper.CreateUriFromUrl(requestUrl), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -591,9 +590,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> HeadAsync(Uri requestUri)
+        public Task<WebDavResponseMessage> HeadAsync(Uri requestUri)
         {
-            return await HeadAsync(requestUri, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return HeadAsync(requestUri, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -602,9 +601,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> HeadAsync(string requestUrl, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> HeadAsync(string requestUrl, CancellationToken cancellationToken)
         {
-            return await HeadAsync(UriHelper.CreateUriFromUrl(requestUrl), HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return HeadAsync(UriHelper.CreateUriFromUrl(requestUrl), HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -613,9 +612,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> HeadAsync(Uri requestUri, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> HeadAsync(Uri requestUri, CancellationToken cancellationToken)
         {
-            return await HeadAsync(requestUri, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return HeadAsync(requestUri, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -624,9 +623,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> HeadAsync(string requestUrl, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> HeadAsync(string requestUrl, HttpCompletionOption completionOption)
         {
-            return await HeadAsync(UriHelper.CreateUriFromUrl(requestUrl), completionOption, CancellationToken.None);
+            return HeadAsync(UriHelper.CreateUriFromUrl(requestUrl), completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -635,9 +634,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> HeadAsync(Uri requestUri, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> HeadAsync(Uri requestUri, HttpCompletionOption completionOption)
         {
-            return await HeadAsync(requestUri, completionOption, CancellationToken.None);
+            return HeadAsync(requestUri, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -647,9 +646,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> HeadAsync(string requestUrl, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> HeadAsync(string requestUrl, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await HeadAsync(UriHelper.CreateUriFromUrl(requestUrl), completionOption, cancellationToken);
+            return HeadAsync(UriHelper.CreateUriFromUrl(requestUrl), completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -659,13 +658,12 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> HeadAsync(Uri requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> HeadAsync(Uri requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             var requestMethod = new HttpRequestMessage(HttpMethod.Head, requestUri);
             SetHttpVersion(requestMethod);
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         #endregion Head
@@ -682,9 +680,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <param name="lockInfo">The <see cref="LockInfo"/> object specifying the lock.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo)
+        public Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo)
         {
-            return await LockAsync(requestUrl, timeout, depth, lockInfo, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return LockAsync(requestUrl, timeout, depth, lockInfo, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -695,9 +693,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <param name="lockInfo">The <see cref="LockInfo"/> object specifying the lock.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo)
+        public Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo)
         {
-            return await LockAsync(requestUri, timeout, depth, lockInfo, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return LockAsync(requestUri, timeout, depth, lockInfo, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -708,9 +706,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <param name="lockInfoXmlString">The XML string specifying which item should be locked.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockInfoXmlString)
+        public Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockInfoXmlString)
         {
-            return await LockAsync(requestUrl, timeout, depth, lockInfoXmlString, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return LockAsync(requestUrl, timeout, depth, lockInfoXmlString, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -721,9 +719,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <param name="lockinfoXmlString">The XML string specifying which item should be locked.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockinfoXmlString)
+        public Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockinfoXmlString)
         {
-            return await LockAsync(requestUri, timeout, depth, lockinfoXmlString, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return LockAsync(requestUri, timeout, depth, lockinfoXmlString, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -735,9 +733,9 @@ namespace DecaTec.WebDav
         /// <param name="lockInfo">The <see cref="LockInfo"/> object specifying the lock.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, CancellationToken cancellationToken)
         {
-            return await LockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, depth, lockInfo, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return LockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, depth, lockInfo, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -749,14 +747,14 @@ namespace DecaTec.WebDav
         /// <param name="lockInfo">The <see cref="LockInfo"/> object specifying the lock.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, CancellationToken cancellationToken)
         {
             string requestContentString = string.Empty;
 
             if (lockInfo != null)
                 requestContentString = WebDavHelper.GetUtf8EncodedXmlWebDavRequestString(LockInfoSerializer, lockInfo);
 
-            return await LockAsync(requestUri, timeout, depth, requestContentString, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return LockAsync(requestUri, timeout, depth, requestContentString, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -768,9 +766,9 @@ namespace DecaTec.WebDav
         /// <param name="lockInfoXmlString">The XML string specifying which item should be locked.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockInfoXmlString, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockInfoXmlString, CancellationToken cancellationToken)
         {
-            return await LockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, depth, lockInfoXmlString, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return LockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, depth, lockInfoXmlString, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -782,9 +780,9 @@ namespace DecaTec.WebDav
         /// <param name="lockinfoXmlString">The XML string specifying which item should be locked.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockinfoXmlString, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockinfoXmlString, CancellationToken cancellationToken)
         {
-            return await LockAsync(requestUri, timeout, depth, lockinfoXmlString, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return LockAsync(requestUri, timeout, depth, lockinfoXmlString, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -796,9 +794,9 @@ namespace DecaTec.WebDav
         /// <param name="lockInfo">The <see cref="LockInfo"/> object specifying the lock.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, HttpCompletionOption completionOption)
         {
-            return await LockAsync(requestUrl, timeout, depth, lockInfo, completionOption, CancellationToken.None);
+            return LockAsync(requestUrl, timeout, depth, lockInfo, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -810,9 +808,9 @@ namespace DecaTec.WebDav
         /// <param name="lockInfo">The <see cref="LockInfo"/> object specifying the lock.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, HttpCompletionOption completionOption)
         {
-            return await LockAsync(requestUri, timeout, depth, lockInfo, completionOption, CancellationToken.None);
+            return LockAsync(requestUri, timeout, depth, lockInfo, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -824,9 +822,9 @@ namespace DecaTec.WebDav
         /// <param name="lockInfoXmlString">The XML string specifying which item should be locked.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockInfoXmlString, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockInfoXmlString, HttpCompletionOption completionOption)
         {
-            return await LockAsync(requestUrl, timeout, depth, lockInfoXmlString, completionOption, CancellationToken.None);
+            return LockAsync(requestUrl, timeout, depth, lockInfoXmlString, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -838,9 +836,9 @@ namespace DecaTec.WebDav
         /// <param name="lockinfoXmlString">The XML string specifying which item should be locked.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockinfoXmlString, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockinfoXmlString, HttpCompletionOption completionOption)
         {
-            return await LockAsync(requestUri, timeout, depth, lockinfoXmlString, completionOption, CancellationToken.None);
+            return LockAsync(requestUri, timeout, depth, lockinfoXmlString, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -853,9 +851,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await LockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, depth, lockInfo, completionOption, cancellationToken);
+            return LockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, depth, lockInfo, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -868,14 +866,14 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, LockInfo lockInfo, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             string requestContentString = string.Empty;
 
             if (lockInfo != null)
                 requestContentString = WebDavHelper.GetUtf8EncodedXmlWebDavRequestString(LockInfoSerializer, lockInfo);
 
-            return await LockAsync(requestUri, timeout, depth, requestContentString, completionOption, cancellationToken);
+            return LockAsync(requestUri, timeout, depth, requestContentString, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -888,9 +886,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockInfoXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> LockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockInfoXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await LockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, depth, lockInfoXmlString, completionOption, cancellationToken);
+            return LockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, depth, lockInfoXmlString, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -903,7 +901,7 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockinfoXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> LockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, WebDavDepthHeaderValue depth, string lockinfoXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             if (depth == WebDavDepthHeaderValue.One)
                 throw new WebDavException("Values other than '0' or 'infinity' must not be used on a LOCK command.");
@@ -923,8 +921,7 @@ namespace DecaTec.WebDav
                 requestMethod.Content = httpContent;
             }
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         #endregion Set lock
@@ -938,9 +935,9 @@ namespace DecaTec.WebDav
         /// <param name="timeout">The <see cref="WebDavTimeoutHeaderValue"/> to use for the lock. The server might ignore this timeout.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> of the lock which should be refreshed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> RefreshLockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, LockToken lockToken)
+        public Task<WebDavResponseMessage> RefreshLockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, LockToken lockToken)
         {
-            return await RefreshLockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return RefreshLockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -950,9 +947,9 @@ namespace DecaTec.WebDav
         /// <param name="timeout">The <see cref="WebDavTimeoutHeaderValue"/> to use for the lock. The server might ignore this timeout.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> of the lock which should be refreshed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> RefreshLockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, LockToken lockToken)
+        public Task<WebDavResponseMessage> RefreshLockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, LockToken lockToken)
         {
-            return await RefreshLockAsync(requestUri, timeout, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return RefreshLockAsync(requestUri, timeout, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -963,9 +960,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> of the lock which should be refreshed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> RefreshLockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> RefreshLockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await RefreshLockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return RefreshLockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -976,9 +973,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> of the lock which should be refreshed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> RefreshLockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> RefreshLockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await RefreshLockAsync(requestUri, timeout, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return RefreshLockAsync(requestUri, timeout, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -989,9 +986,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> of the lock which should be refreshed.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> RefreshLockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> RefreshLockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await RefreshLockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, lockToken, completionOption, CancellationToken.None);
+            return RefreshLockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1002,9 +999,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> of the lock which should be refreshed.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> RefreshLockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> RefreshLockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await RefreshLockAsync(requestUri, timeout, lockToken, completionOption, CancellationToken.None);
+            return RefreshLockAsync(requestUri, timeout, lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1016,9 +1013,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> RefreshLockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> RefreshLockAsync(string requestUrl, WebDavTimeoutHeaderValue timeout, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await RefreshLockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, lockToken, completionOption, cancellationToken);
+            return RefreshLockAsync(UriHelper.CreateUriFromUrl(requestUrl), timeout, lockToken, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1030,7 +1027,7 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> RefreshLockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> RefreshLockAsync(Uri requestUri, WebDavTimeoutHeaderValue timeout, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             if (lockToken == null)
                 throw new WebDavException("No lock token specified. A lock token is required to refresh a lock.");
@@ -1043,8 +1040,7 @@ namespace DecaTec.WebDav
 
             requestMethod.Headers.Add(WebDavRequestHeader.If, lockToken.IfHeaderNoTagListFormat.ToString());
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         #endregion Refresh lock
@@ -1057,9 +1053,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> of a locked resource which should be unlocked.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UnlockAsync(string requestUrl, LockToken lockToken)
+        public Task<WebDavResponseMessage> UnlockAsync(string requestUrl, LockToken lockToken)
         {
-            return await UnlockAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return UnlockAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1068,9 +1064,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> of a locked resource which should be unlocked.</param>
         /// <returns>The <see cref="Task"/>t representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UnlockAsync(Uri requestUri, LockToken lockToken)
+        public Task<WebDavResponseMessage> UnlockAsync(Uri requestUri, LockToken lockToken)
         {
-            return await UnlockAsync(requestUri, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return UnlockAsync(requestUri, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1080,9 +1076,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> of a locked resource which should be unlocked.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UnlockAsync(string requestUrl, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> UnlockAsync(string requestUrl, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await UnlockAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return UnlockAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1092,9 +1088,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> of a locked resource which should be unlocked.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UnlockAsync(Uri requestUri, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> UnlockAsync(Uri requestUri, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await UnlockAsync(requestUri, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return UnlockAsync(requestUri, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1104,9 +1100,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> of a locked resource which should be unlocked.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UnlockAsync(string requestUrl, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> UnlockAsync(string requestUrl, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await UnlockAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, completionOption, CancellationToken.None);
+            return UnlockAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1116,9 +1112,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> of a locked resource which should be unlocked.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UnlockAsync(Uri requestUri, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> UnlockAsync(Uri requestUri, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await UnlockAsync(requestUri, lockToken, completionOption, CancellationToken.None);
+            return UnlockAsync(requestUri, lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1129,9 +1125,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UnlockAsync(string requestUrl, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> UnlockAsync(string requestUrl, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await UnlockAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, completionOption, cancellationToken);
+            return UnlockAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1142,7 +1138,7 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UnlockAsync(Uri requestUri, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> UnlockAsync(Uri requestUri, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             if (lockToken == null)
                 throw new WebDavException("No lock token specified. A lock token is required for unlocking.");
@@ -1152,8 +1148,7 @@ namespace DecaTec.WebDav
 
             requestMethod.Headers.Add(WebDavRequestHeader.LockToken, lockToken.LockTokenHeaderFormat.ToString());
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         #endregion Unlock
@@ -1167,9 +1162,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUrl">The URL of the collection to create.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(string requestUrl)
+        public Task<WebDavResponseMessage> MkcolAsync(string requestUrl)
         {
-            return await MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1177,9 +1172,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUri">The <see cref="Uri"/> of the collection to create.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(Uri requestUri)
+        public Task<WebDavResponseMessage> MkcolAsync(Uri requestUri)
         {
-            return await MkcolAsync(requestUri, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MkcolAsync(requestUri, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1188,9 +1183,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL of the collection to create.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(string requestUrl, LockToken lockToken)
+        public Task<WebDavResponseMessage> MkcolAsync(string requestUrl, LockToken lockToken)
         {
-            return await MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1199,9 +1194,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> of the collection to create.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, LockToken lockToken)
+        public Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, LockToken lockToken)
         {
-            return await MkcolAsync(requestUri, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MkcolAsync(requestUri, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1210,9 +1205,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL of the collection to create.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(string requestUrl, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MkcolAsync(string requestUrl, CancellationToken cancellationToken)
         {
-            return await MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), null, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1221,9 +1216,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> of the collection to create.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, CancellationToken cancellationToken)
         {
-            return await MkcolAsync(requestUri, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return MkcolAsync(requestUri, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1233,9 +1228,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(string requestUrl, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MkcolAsync(string requestUrl, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1245,9 +1240,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await MkcolAsync(requestUri, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return MkcolAsync(requestUri, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1256,9 +1251,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL of the collection to create.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(string requestUrl, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> MkcolAsync(string requestUrl, HttpCompletionOption completionOption)
         {
-            return await MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), null, completionOption, CancellationToken.None);
+            return MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), null, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1267,9 +1262,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> of the collection to create.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, HttpCompletionOption completionOption)
         {
-            return await MkcolAsync(requestUri, null, completionOption, CancellationToken.None);
+            return MkcolAsync(requestUri, null, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1279,9 +1274,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(string requestUrl, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> MkcolAsync(string requestUrl, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, completionOption, CancellationToken.None);
+            return MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1291,9 +1286,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await MkcolAsync(requestUri, lockToken, completionOption, CancellationToken.None);
+            return MkcolAsync(requestUri, lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1303,9 +1298,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(string requestUrl, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MkcolAsync(string requestUrl, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), null, completionOption, cancellationToken);
+            return MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), null, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1315,9 +1310,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await MkcolAsync(requestUri, null, completionOption, cancellationToken);
+            return MkcolAsync(requestUri, null, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1328,9 +1323,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(string requestUrl, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MkcolAsync(string requestUrl, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, completionOption, cancellationToken);
+            return MkcolAsync(UriHelper.CreateUriFromUrl(requestUrl), lockToken, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1341,7 +1336,7 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MkcolAsync(Uri requestUri, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             var requestMethod = new HttpRequestMessage(WebDavMethod.Mkcol, requestUri);
             SetHttpVersion(requestMethod);
@@ -1349,8 +1344,7 @@ namespace DecaTec.WebDav
             if (lockToken != null)
                 requestMethod.Headers.Add(WebDavRequestHeader.If, lockToken.IfHeaderNoTagListFormat.ToString());
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         #endregion Mkcol
@@ -1363,9 +1357,9 @@ namespace DecaTec.WebDav
         /// <param name="sourceUrl">The URL of the resource which should be moved.</param>
         /// <param name="destinationUrl">The target URL.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl)
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false, null, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false, null, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1374,9 +1368,9 @@ namespace DecaTec.WebDav
         /// <param name="sourceUri">The <see cref="Uri"/> of the resource which should be moved.</param>
         /// <param name="destinationUri">The target <see cref="Uri"/>.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri)
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri)
         {
-            return await MoveAsync(sourceUri, destinationUri, false, null, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MoveAsync(sourceUri, destinationUri, false, null, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1386,9 +1380,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUrl">The target URL.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite)
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, null, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, null, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1398,9 +1392,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUri">The target <see cref="Uri"/>.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite)
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite)
         {
-            return await MoveAsync(sourceUri, destinationUri, overwrite, null, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MoveAsync(sourceUri, destinationUri, overwrite, null, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1411,9 +1405,9 @@ namespace DecaTec.WebDav
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, CancellationToken cancellationToken)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, null, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, null, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1424,9 +1418,9 @@ namespace DecaTec.WebDav
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, CancellationToken cancellationToken)
         {
-            return await MoveAsync(sourceUri, destinationUri, overwrite, null, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return MoveAsync(sourceUri, destinationUri, overwrite, null, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1437,9 +1431,9 @@ namespace DecaTec.WebDav
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, HttpCompletionOption completionOption)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, null, null, completionOption, CancellationToken.None);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, null, null, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1450,9 +1444,9 @@ namespace DecaTec.WebDav
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, HttpCompletionOption completionOption)
         {
-            return await MoveAsync(sourceUri, destinationUri, overwrite, null, null, completionOption, CancellationToken.None);
+            return MoveAsync(sourceUri, destinationUri, overwrite, null, null, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1464,9 +1458,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, null, null, completionOption, cancellationToken);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, null, null, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1478,9 +1472,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await MoveAsync(sourceUri, destinationUri, overwrite, null, null, completionOption, cancellationToken);
+            return MoveAsync(sourceUri, destinationUri, overwrite, null, null, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1492,9 +1486,9 @@ namespace DecaTec.WebDav
         /// <param name="lockTokenSource">The <see cref="LockToken"/> of the source. Specify null if the source is not locked.</param>
         /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination)
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, lockTokenSource, lockTokenDestination, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, lockTokenSource, lockTokenDestination, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1506,9 +1500,9 @@ namespace DecaTec.WebDav
         /// <param name="lockTokenSource">The <see cref="LockToken"/> of the source. Specify null if the source is not locked.</param>
         /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination)
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination)
         {
-            return await MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1521,9 +1515,9 @@ namespace DecaTec.WebDav
         /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, CancellationToken cancellationToken)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, lockTokenSource, lockTokenDestination, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, lockTokenSource, lockTokenDestination, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1536,39 +1530,9 @@ namespace DecaTec.WebDav
         /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, CancellationToken cancellationToken)
         {
-            return await MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination, HttpCompletionOption.ResponseContentRead, cancellationToken);
-        }
-
-        /// <summary>
-        /// Moves a resource to another URL.
-        /// </summary>
-        /// <param name="sourceUrl">The URL of the resource which should be moved.</param>
-        /// <param name="destinationUrl">The target URL.</param>
-        /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="lockTokenSource">The <see cref="LockToken"/> of the source. Specify null if the source is not locked.</param>
-        /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
-        /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
-        /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, HttpCompletionOption completionOption)
-        {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, lockTokenSource, lockTokenDestination, completionOption, CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Moves a resource to another <see cref="Uri"/>.
-        /// </summary>
-        /// <param name="sourceUri">The <see cref="Uri"/> of the resource which should be moved.</param>
-        /// <param name="destinationUri">The target <see cref="Uri"/>.</param>
-        /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="lockTokenSource">The <see cref="LockToken"/> of the source. Specify null if the source is not locked.</param>
-        /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
-        /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
-        /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, HttpCompletionOption completionOption)
-        {
-            return await MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination, completionOption, CancellationToken.None);
+            return MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1580,11 +1544,41 @@ namespace DecaTec.WebDav
         /// <param name="lockTokenSource">The <see cref="LockToken"/> of the source. Specify null if the source is not locked.</param>
         /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
+        /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, HttpCompletionOption completionOption)
+        {
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, lockTokenSource, lockTokenDestination, completionOption, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Moves a resource to another <see cref="Uri"/>.
+        /// </summary>
+        /// <param name="sourceUri">The <see cref="Uri"/> of the resource which should be moved.</param>
+        /// <param name="destinationUri">The target <see cref="Uri"/>.</param>
+        /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="lockTokenSource">The <see cref="LockToken"/> of the source. Specify null if the source is not locked.</param>
+        /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
+        /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
+        /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, HttpCompletionOption completionOption)
+        {
+            return MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination, completionOption, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Moves a resource to another URL.
+        /// </summary>
+        /// <param name="sourceUrl">The URL of the resource which should be moved.</param>
+        /// <param name="destinationUrl">The target URL.</param>
+        /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="lockTokenSource">The <see cref="LockToken"/> of the source. Specify null if the source is not locked.</param>
+        /// <param name="lockTokenDestination">The <see cref="LockToken"/> of the destination. Specify null if the destination is not locked.</param>
+        /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, lockTokenSource, lockTokenDestination, completionOption, cancellationToken);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, lockTokenSource, lockTokenDestination, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1598,7 +1592,7 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, LockToken lockTokenSource, LockToken lockTokenDestination, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             var requestMethod = new HttpRequestMessage(WebDavMethod.Move, sourceUri);
             SetHttpVersion(requestMethod);
@@ -1629,8 +1623,7 @@ namespace DecaTec.WebDav
             else
                 requestMethod.Headers.Add(WebDavRequestHeader.Overwrite, WebDavOverwriteHeaderValue.NoOverwrite);
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         #endregion Move
@@ -1643,9 +1636,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> PostAsync(string requestUrl, HttpContent content)
+        public new Task<WebDavResponseMessage> PostAsync(string requestUrl, HttpContent content)
         {
-            return await PostAsync(UriHelper.CreateUriFromUrl(requestUrl), content, null, CancellationToken.None);
+            return PostAsync(UriHelper.CreateUriFromUrl(requestUrl), content, null, CancellationToken.None);
         }
 
         /// <summary>
@@ -1654,9 +1647,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> PostAsync(Uri requestUri, HttpContent content)
+        public new Task<WebDavResponseMessage> PostAsync(Uri requestUri, HttpContent content)
         {
-            return await PostAsync(requestUri, content, null, CancellationToken.None);
+            return PostAsync(requestUri, content, null, CancellationToken.None);
         }
 
         /// <summary>
@@ -1666,9 +1659,9 @@ namespace DecaTec.WebDav
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PostAsync(string requestUrl, HttpContent content, LockToken lockToken)
+        public Task<WebDavResponseMessage> PostAsync(string requestUrl, HttpContent content, LockToken lockToken)
         {
-            return await PostAsync(UriHelper.CreateUriFromUrl(requestUrl), content, lockToken, CancellationToken.None);
+            return PostAsync(UriHelper.CreateUriFromUrl(requestUrl), content, lockToken, CancellationToken.None);
         }
 
         /// <summary>
@@ -1678,9 +1671,9 @@ namespace DecaTec.WebDav
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PostAsync(Uri requestUri, HttpContent content, LockToken lockToken)
+        public Task<WebDavResponseMessage> PostAsync(Uri requestUri, HttpContent content, LockToken lockToken)
         {
-            return await PostAsync(requestUri, content, lockToken, CancellationToken.None);
+            return PostAsync(requestUri, content, lockToken, CancellationToken.None);
         }
 
         /// <summary>
@@ -1690,9 +1683,9 @@ namespace DecaTec.WebDav
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> PostAsync(string requestUrl, HttpContent content, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> PostAsync(string requestUrl, HttpContent content, CancellationToken cancellationToken)
         {
-            return await PostAsync(UriHelper.CreateUriFromUrl(requestUrl), content, null, cancellationToken);
+            return PostAsync(UriHelper.CreateUriFromUrl(requestUrl), content, null, cancellationToken);
         }
 
         /// <summary>
@@ -1702,9 +1695,9 @@ namespace DecaTec.WebDav
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> PostAsync(Uri requestUri, HttpContent content, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> PostAsync(Uri requestUri, HttpContent content, CancellationToken cancellationToken)
         {
-            return await PostAsync(requestUri, content, null, cancellationToken);
+            return PostAsync(requestUri, content, null, cancellationToken);
         }
 
         /// <summary>
@@ -1715,9 +1708,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PostAsync(string requestUrl, HttpContent content, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PostAsync(string requestUrl, HttpContent content, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await PostAsync(UriHelper.CreateUriFromUrl(requestUrl), content, lockToken, cancellationToken);
+            return PostAsync(UriHelper.CreateUriFromUrl(requestUrl), content, lockToken, cancellationToken);
         }
 
         /// <summary>
@@ -1728,7 +1721,7 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PostAsync(Uri requestUri, HttpContent content, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PostAsync(Uri requestUri, HttpContent content, LockToken lockToken, CancellationToken cancellationToken)
         {
             var requestMethod = new HttpRequestMessage(WebDavMethod.Post, requestUri)
             {
@@ -1740,8 +1733,7 @@ namespace DecaTec.WebDav
             if (lockToken != null)
                 requestMethod.Headers.Add(WebDavRequestHeader.If, lockToken.IfHeaderNoTagListFormat.ToString());
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, HttpCompletionOption.ResponseContentRead, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         #endregion Post
@@ -1753,9 +1745,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUrl">The URL the request is sent to.</param>       
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), WebDavDepthHeaderValue.One, string.Empty, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), WebDavDepthHeaderValue.One, string.Empty, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1763,9 +1755,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>       
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri)
         {
-            return await PropFindAsync(requestUri, WebDavDepthHeaderValue.One, string.Empty, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropFindAsync(requestUri, WebDavDepthHeaderValue.One, string.Empty, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1774,9 +1766,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>       
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, string.Empty, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, string.Empty, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1785,9 +1777,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>       
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth)
         {
-            return await PropFindAsync(requestUri, depth, string.Empty, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropFindAsync(requestUri, depth, string.Empty, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1797,9 +1789,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <param name="propfindXmlString">The XML string specifying which items should be returned by the response. If an empty string is specified here, a so called 'allprop' request will be sent.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, string propfindXmlString)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, string propfindXmlString)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfindXmlString, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfindXmlString, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1809,9 +1801,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <param name="propfindXmlString">The XML string specifying which items should be returned by the response. If an empty string is specified here, a so called 'allprop' request will be sent.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, string propfindXmlString)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, string propfindXmlString)
         {
-            return await PropFindAsync(requestUri, depth, propfindXmlString, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropFindAsync(requestUri, depth, propfindXmlString, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1821,9 +1813,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <param name="propfind">The <see cref="PropFind"/> object specifying which properties should be searched for. If null is specified here, a so called 'allprop' request will be sent.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, PropFind propfind)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, PropFind propfind)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfind, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfind, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1833,9 +1825,9 @@ namespace DecaTec.WebDav
         /// <param name="depth">The <see cref="WebDavDepthHeaderValue"/> to use for the operation.</param>
         /// <param name="propfind">The <see cref="PropFind"/> object specifying which properties should be searched for. If null is specified here, a so called 'allprop' request will be sent.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, PropFind propfind)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, PropFind propfind)
         {
-            return await PropFindAsync(requestUri, depth, propfind, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropFindAsync(requestUri, depth, propfind, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -1846,9 +1838,9 @@ namespace DecaTec.WebDav
         /// <param name="propfindXmlString">The XML string specifying which items should be returned by the response. If an empty string is specified here, a so called 'allprop' request will be sent.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, string propfindXmlString, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, string propfindXmlString, CancellationToken cancellationToken)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfindXmlString, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfindXmlString, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1859,9 +1851,9 @@ namespace DecaTec.WebDav
         /// <param name="propfindXmlString">The XML string specifying which items should be returned by the response. If an empty string is specified here, a so called 'allprop' request will be sent.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, string propfindXmlString, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, string propfindXmlString, CancellationToken cancellationToken)
         {
-            return await PropFindAsync(requestUri, depth, propfindXmlString, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropFindAsync(requestUri, depth, propfindXmlString, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1872,9 +1864,9 @@ namespace DecaTec.WebDav
         /// <param name="propfind">The <see cref="PropFind"/> object specifying which properties should be searched for. If null is specified here, a so called 'allprop' request will be sent.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, PropFind propfind, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, PropFind propfind, CancellationToken cancellationToken)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfind, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfind, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1885,9 +1877,9 @@ namespace DecaTec.WebDav
         /// <param name="propfind">The <see cref="PropFind"/> object specifying which properties should be searched for. If null is specified here, a so called 'allprop' request will be sent.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, PropFind propfind, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, PropFind propfind, CancellationToken cancellationToken)
         {
-            return await PropFindAsync(requestUri, depth, propfind, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropFindAsync(requestUri, depth, propfind, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1898,9 +1890,9 @@ namespace DecaTec.WebDav
         /// <param name="propfindXmlString">The XML string specifying which items should be returned by the response. If an empty string is specified here, a so called 'allprop' request will be sent.</param>
         /// <param name="completionOption">An <see cref="HttpContent"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, string propfindXmlString, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, string propfindXmlString, HttpCompletionOption completionOption)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfindXmlString, completionOption, CancellationToken.None);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfindXmlString, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1911,9 +1903,9 @@ namespace DecaTec.WebDav
         /// <param name="propfindXmlString">The XML string specifying which items should be returned by the response. If an empty string is specified here, a so called 'allprop' request will be sent.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, string propfindXmlString, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, string propfindXmlString, HttpCompletionOption completionOption)
         {
-            return await PropFindAsync(requestUri, depth, propfindXmlString, completionOption, CancellationToken.None);
+            return PropFindAsync(requestUri, depth, propfindXmlString, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1924,9 +1916,9 @@ namespace DecaTec.WebDav
         /// <param name="propfind">The <see cref="PropFind"/> object specifying which properties should be searched for. If null is specified here, a so called 'allprop' request will be sent.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, PropFind propfind, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, PropFind propfind, HttpCompletionOption completionOption)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfind, completionOption, CancellationToken.None);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfind, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1937,9 +1929,9 @@ namespace DecaTec.WebDav
         /// <param name="propfind">The <see cref="PropFind"/> object specifying which properties should be searched for. If null is specified here, a so called 'allprop' request will be sent.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, PropFind propfind, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, PropFind propfind, HttpCompletionOption completionOption)
         {
-            return await PropFindAsync(requestUri, depth, propfind, completionOption, CancellationToken.None);
+            return PropFindAsync(requestUri, depth, propfind, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -1951,9 +1943,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/>  value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, string propfindXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, string propfindXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfindXmlString, completionOption, cancellationToken);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfindXmlString, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1965,7 +1957,7 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, string propfindXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, string propfindXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             // Client must submit a depth header.
             if (depth == null)
@@ -1983,8 +1975,7 @@ namespace DecaTec.WebDav
                 requestMethod.Content = httpContent;
             }
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -1996,9 +1987,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, PropFind propfind, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropFindAsync(string requestUrl, WebDavDepthHeaderValue depth, PropFind propfind, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfind, completionOption, cancellationToken);
+            return PropFindAsync(UriHelper.CreateUriFromUrl(requestUrl), depth, propfind, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -2010,14 +2001,14 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, PropFind propfind, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropFindAsync(Uri requestUri, WebDavDepthHeaderValue depth, PropFind propfind, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             string requestContentString = string.Empty;
 
             if (propfind != null)
                 requestContentString = WebDavHelper.GetUtf8EncodedXmlWebDavRequestString(PropFindSerializer, propfind);
 
-            return await PropFindAsync(requestUri, depth, requestContentString, completionOption, cancellationToken);
+            return PropFindAsync(requestUri, depth, requestContentString, completionOption, cancellationToken);
         }
 
         #endregion Propfind
@@ -2030,9 +2021,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="propPatchXmlString">The XML string specifying which changes to which properties should be sent with this request.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2041,9 +2032,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="propPatchXmlString">The XML string specifying which changes to which properties should be sent with this request.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString)
         {
-            return await PropPatchAsync(requestUri, propPatchXmlString, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropPatchAsync(requestUri, propPatchXmlString, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2052,9 +2043,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="propertyUpdate">A <see cref="PropertyUpdate"/> which specifies the properties and values which should be updated.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2063,9 +2054,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="propertyUpdate">A <see cref="PropertyUpdate"/> which specifies the properties and values which should be updated.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate)
         {
-            return await PropPatchAsync(requestUri, propertyUpdate, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropPatchAsync(requestUri, propertyUpdate, null, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2075,9 +2066,9 @@ namespace DecaTec.WebDav
         /// <param name="propPatchXmlString">The XML string specifying which changes to which properties should be sent with this request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2087,9 +2078,9 @@ namespace DecaTec.WebDav
         /// <param name="propPatchXmlString">The XML string specifying which changes to which properties should be sent with this request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(requestUri, propPatchXmlString, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropPatchAsync(requestUri, propPatchXmlString, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2099,9 +2090,9 @@ namespace DecaTec.WebDav
         /// <param name="propertyUpdate">A <see cref="PropertyUpdate"/> which specifies the properties and values which should be updated.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2111,14 +2102,14 @@ namespace DecaTec.WebDav
         /// <param name="propertyUpdate">A <see cref="PropertyUpdate"/> which specifies the properties and values which should be updated.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, CancellationToken cancellationToken)
         {
             string requestContentString = string.Empty;
 
             if (propertyUpdate != null)
                 requestContentString = WebDavHelper.GetUtf8EncodedXmlWebDavRequestString(PropertyUpdateSerializer, propertyUpdate);
 
-            return await PropPatchAsync(requestUri, requestContentString, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropPatchAsync(requestUri, requestContentString, null, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2128,9 +2119,9 @@ namespace DecaTec.WebDav
         /// <param name="propPatchXmlString">The XML string specifying which changes to which properties should be sent with this request.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, HttpCompletionOption completionOption)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, null, completionOption, CancellationToken.None);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, null, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2140,9 +2131,9 @@ namespace DecaTec.WebDav
         /// <param name="propPatchXmlString">The XML string specifying which changes to which properties should be sent with this request.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, HttpCompletionOption completionOption)
         {
-            return await PropPatchAsync(requestUri, propPatchXmlString, null, completionOption, CancellationToken.None);
+            return PropPatchAsync(requestUri, propPatchXmlString, null, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2152,9 +2143,9 @@ namespace DecaTec.WebDav
         /// <param name="propertyUpdate">A <see cref="PropertyUpdate"/> which specifies the properties and values which should be updated.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, HttpCompletionOption completionOption)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, null, completionOption, CancellationToken.None);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, null, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2164,9 +2155,9 @@ namespace DecaTec.WebDav
         /// <param name="propertyUpdate">A <see cref="PropertyUpdate"/> which specifies the properties and values which should be updated.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, HttpCompletionOption completionOption)
         {
-            return await PropPatchAsync(requestUri, propertyUpdate, null, completionOption, CancellationToken.None);
+            return PropPatchAsync(requestUri, propertyUpdate, null, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2177,9 +2168,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, null, completionOption, cancellationToken);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, null, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -2190,9 +2181,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(requestUri, propPatchXmlString, null, completionOption, cancellationToken);
+            return PropPatchAsync(requestUri, propPatchXmlString, null, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -2203,9 +2194,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, null, completionOption, cancellationToken);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, null, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -2216,14 +2207,14 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             string requestContentString = string.Empty;
 
             if (propertyUpdate != null)
                 requestContentString = WebDavHelper.GetUtf8EncodedXmlWebDavRequestString(PropertyUpdateSerializer, propertyUpdate);
 
-            return await PropPatchAsync(requestUri, requestContentString, null, completionOption, cancellationToken);
+            return PropPatchAsync(requestUri, requestContentString, null, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -2233,9 +2224,9 @@ namespace DecaTec.WebDav
         /// <param name="propPatchXmlString">The XML string specifying which changes to which properties should be sent with this request.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, LockToken lockToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, LockToken lockToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2245,9 +2236,9 @@ namespace DecaTec.WebDav
         /// <param name="propPatchXmlString">The XML string specifying which changes to which properties should be sent with this request.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, LockToken lockToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, LockToken lockToken)
         {
-            return await PropPatchAsync(requestUri, propPatchXmlString, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropPatchAsync(requestUri, propPatchXmlString, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2257,9 +2248,9 @@ namespace DecaTec.WebDav
         /// <param name="propertyUpdate">A <see cref="PropertyUpdate"/> which specifies the properties and values which should be updated.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, LockToken lockToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, LockToken lockToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2269,9 +2260,9 @@ namespace DecaTec.WebDav
         /// <param name="propertyUpdate">A <see cref="PropertyUpdate"/> which specifies the properties and values which should be updated.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, LockToken lockToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, LockToken lockToken)
         {
-            return await PropPatchAsync(requestUri, propertyUpdate, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return PropPatchAsync(requestUri, propertyUpdate, lockToken, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2282,9 +2273,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2295,9 +2286,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(requestUri, propPatchXmlString, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropPatchAsync(requestUri, propPatchXmlString, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2308,9 +2299,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2321,14 +2312,14 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, LockToken lockToken, CancellationToken cancellationToken)
         {
             string requestContentString = string.Empty;
 
             if (propertyUpdate != null)
                 requestContentString = WebDavHelper.GetUtf8EncodedXmlWebDavRequestString(PropertyUpdateSerializer, propertyUpdate);
 
-            return await PropPatchAsync(requestUri, requestContentString, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return PropPatchAsync(requestUri, requestContentString, lockToken, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2339,9 +2330,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, lockToken, completionOption, CancellationToken.None);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2352,9 +2343,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await PropPatchAsync(requestUri, propPatchXmlString, lockToken, completionOption, CancellationToken.None);
+            return PropPatchAsync(requestUri, propPatchXmlString, lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2365,9 +2356,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, lockToken, completionOption, CancellationToken.None);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2378,9 +2369,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, LockToken lockToken, HttpCompletionOption completionOption)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, LockToken lockToken, HttpCompletionOption completionOption)
         {
-            return await PropPatchAsync(requestUri, propertyUpdate, lockToken, completionOption, CancellationToken.None);
+            return PropPatchAsync(requestUri, propertyUpdate, lockToken, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2392,9 +2383,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, string propPatchXmlString, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, lockToken, completionOption, cancellationToken);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propPatchXmlString, lockToken, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -2406,7 +2397,7 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, string propPatchXmlString, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             var requestMethod = new HttpRequestMessage(WebDavMethod.PropPatch, requestUri);
             SetHttpVersion(requestMethod);
@@ -2420,8 +2411,7 @@ namespace DecaTec.WebDav
                 requestMethod.Content = httpContent;
             }
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, completionOption, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -2433,9 +2423,9 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(string requestUrl, PropertyUpdate propertyUpdate, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
-            return await PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, lockToken, completionOption, cancellationToken);
+            return PropPatchAsync(UriHelper.CreateUriFromUrl(requestUrl), propertyUpdate, lockToken, completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -2447,14 +2437,14 @@ namespace DecaTec.WebDav
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PropPatchAsync(Uri requestUri, PropertyUpdate propertyUpdate, LockToken lockToken, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             string requestContentString = string.Empty;
 
             if (propertyUpdate != null)
                 requestContentString = WebDavHelper.GetUtf8EncodedXmlWebDavRequestString(PropertyUpdateSerializer, propertyUpdate);
 
-            return await PropPatchAsync(requestUri, requestContentString, lockToken, completionOption, cancellationToken);
+            return PropPatchAsync(requestUri, requestContentString, lockToken, completionOption, cancellationToken);
         }
 
         #endregion Proppatch
@@ -2467,9 +2457,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUrl">The URL the request is sent to.</param>
         /// <param name="content">The <see cref="HttpContent"/> content sent to the server.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> PutAsync(string requestUrl, HttpContent content)
+        public new Task<WebDavResponseMessage> PutAsync(string requestUrl, HttpContent content)
         {
-            return await PutAsync(UriHelper.CreateUriFromUrl(requestUrl), content, null, CancellationToken.None);
+            return PutAsync(UriHelper.CreateUriFromUrl(requestUrl), content, null, CancellationToken.None);
         }
 
         /// <summary>
@@ -2478,9 +2468,9 @@ namespace DecaTec.WebDav
         /// <param name="requestUri">The <see cref="Uri"/> the request is sent to.</param>
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> PutAsync(Uri requestUri, HttpContent content)
+        public new Task<WebDavResponseMessage> PutAsync(Uri requestUri, HttpContent content)
         {
-            return await PutAsync(requestUri, content, null, CancellationToken.None);
+            return PutAsync(requestUri, content, null, CancellationToken.None);
         }
 
         /// <summary>
@@ -2490,9 +2480,9 @@ namespace DecaTec.WebDav
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PutAsync(string requestUrl, HttpContent content, LockToken lockToken)
+        public Task<WebDavResponseMessage> PutAsync(string requestUrl, HttpContent content, LockToken lockToken)
         {
-            return await PutAsync(UriHelper.CreateUriFromUrl(requestUrl), content, lockToken, CancellationToken.None);
+            return PutAsync(UriHelper.CreateUriFromUrl(requestUrl), content, lockToken, CancellationToken.None);
         }
 
         /// <summary>
@@ -2502,9 +2492,9 @@ namespace DecaTec.WebDav
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PutAsync(Uri requestUri, HttpContent content, LockToken lockToken)
+        public Task<WebDavResponseMessage> PutAsync(Uri requestUri, HttpContent content, LockToken lockToken)
         {
-            return await PutAsync(requestUri, content, lockToken, CancellationToken.None);
+            return PutAsync(requestUri, content, lockToken, CancellationToken.None);
         }
 
         /// <summary>
@@ -2514,9 +2504,9 @@ namespace DecaTec.WebDav
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> PutAsync(string requestUrl, HttpContent content, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> PutAsync(string requestUrl, HttpContent content, CancellationToken cancellationToken)
         {
-            return await PutAsync(UriHelper.CreateUriFromUrl(requestUrl), content, null, cancellationToken);
+            return PutAsync(UriHelper.CreateUriFromUrl(requestUrl), content, null, cancellationToken);
         }
 
         /// <summary>
@@ -2526,9 +2516,9 @@ namespace DecaTec.WebDav
         /// <param name="content">The <see cref="HttpContent"/> sent to the server.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> PutAsync(Uri requestUri, HttpContent content, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> PutAsync(Uri requestUri, HttpContent content, CancellationToken cancellationToken)
         {
-            return await PutAsync(requestUri, content, null, cancellationToken);
+            return PutAsync(requestUri, content, null, cancellationToken);
         }
 
         /// <summary>
@@ -2539,9 +2529,9 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PutAsync(string requestUrl, HttpContent content, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PutAsync(string requestUrl, HttpContent content, LockToken lockToken, CancellationToken cancellationToken)
         {
-            return await PutAsync(UriHelper.CreateUriFromUrl(requestUrl), content, lockToken, cancellationToken);
+            return PutAsync(UriHelper.CreateUriFromUrl(requestUrl), content, lockToken, cancellationToken);
         }
 
         /// <summary>
@@ -2552,7 +2542,7 @@ namespace DecaTec.WebDav
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> PutAsync(Uri requestUri, HttpContent content, LockToken lockToken, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> PutAsync(Uri requestUri, HttpContent content, LockToken lockToken, CancellationToken cancellationToken)
         {
             var requestMethod = new HttpRequestMessage(WebDavMethod.Put, requestUri)
             {
@@ -2564,8 +2554,7 @@ namespace DecaTec.WebDav
             if (lockToken != null)
                 requestMethod.Headers.Add(WebDavRequestHeader.If, lockToken.IfHeaderNoTagListFormat.ToString());
 
-            var httpResponseMessage = await this.SendAsync(requestMethod, HttpCompletionOption.ResponseContentRead, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         #endregion Put
@@ -2577,9 +2566,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="request">The <see cref="HttpRequestMessage"/> to send.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> SendAsync(HttpRequestMessage request)
+        public new Task<WebDavResponseMessage> SendAsync(HttpRequestMessage request)
         {
-            return await SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
         }
 
         /// <summary>
@@ -2588,9 +2577,9 @@ namespace DecaTec.WebDav
         /// <param name="request">The <see cref="HttpRequestMessage"/> to send.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        public new Task<WebDavResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return await SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -2599,9 +2588,9 @@ namespace DecaTec.WebDav
         /// <param name="request">The <see cref="HttpRequestMessage"/> to send.</param>
         /// <param name="completionOption">An <see cref="HttpCompletionOption"/> value that indicates when the operation should be considered completed.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public new async Task<WebDavResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption)
+        public new Task<WebDavResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption)
         {
-            return await SendAsync(request, completionOption, CancellationToken.None);
+            return SendAsync(request, completionOption, CancellationToken.None);
         }
 
         /// <summary>
@@ -2629,9 +2618,9 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress)
+        public Task<WebDavResponseMessage> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress)
         {
-            return await this.UploadFileWithProgressAsync(url, stream, contentType, progress, CancellationToken.None, null);
+            return this.UploadFileWithProgressAsync(url, stream, contentType, progress, CancellationToken.None, null);
         }
 
         /// <summary>
@@ -2642,9 +2631,9 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress)
+        public Task<WebDavResponseMessage> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress)
         {
-            return await this.UploadFileWithProgressAsync(uri, stream, contentType, progress, CancellationToken.None, null);
+            return this.UploadFileWithProgressAsync(uri, stream, contentType, progress, CancellationToken.None, null);
         }
 
         /// <summary>
@@ -2656,9 +2645,9 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
         {
-            return await this.UploadFileWithProgressAsync(url, stream, contentType, progress, cancellationToken, null);
+            return this.UploadFileWithProgressAsync(url, stream, contentType, progress, cancellationToken, null);
         }
 
         /// <summary>
@@ -2670,9 +2659,9 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         ///  <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
+        public Task<WebDavResponseMessage> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
         {
-            return await this.UploadFileWithProgressAsync(uri, stream, contentType, progress, cancellationToken, null);
+            return this.UploadFileWithProgressAsync(uri, stream, contentType, progress, cancellationToken, null);
         }
 
         /// <summary>
@@ -2684,9 +2673,9 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, LockToken lockToken)
+        public Task<WebDavResponseMessage> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, LockToken lockToken)
         {
-            return await this.UploadFileWithProgressAsync(url, stream, contentType, progress, CancellationToken.None, lockToken);
+            return this.UploadFileWithProgressAsync(url, stream, contentType, progress, CancellationToken.None, lockToken);
         }
 
         /// <summary>
@@ -2698,9 +2687,9 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, LockToken lockToken)
+        public Task<WebDavResponseMessage> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, LockToken lockToken)
         {
-            return await UploadFileWithProgressAsync(uri, stream, contentType, progress, CancellationToken.None, lockToken);
+            return UploadFileWithProgressAsync(uri, stream, contentType, progress, CancellationToken.None, lockToken);
         }
 
         /// <summary>
@@ -2713,9 +2702,9 @@ namespace DecaTec.WebDav
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, LockToken lockToken)
+        public Task<WebDavResponseMessage> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, LockToken lockToken)
         {
-            return await this.UploadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), stream, contentType, progress, cancellationToken, lockToken);
+            return this.UploadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), stream, contentType, progress, cancellationToken, lockToken);
         }
 
         /// <summary>
@@ -2728,7 +2717,7 @@ namespace DecaTec.WebDav
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <param name="lockToken">The <see cref="LockToken"/> to use or null if no lock token should be used.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<WebDavResponseMessage> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, LockToken lockToken)
+        public Task<WebDavResponseMessage> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, LockToken lockToken)
         {
             var streamContent = new WebDavProgressStreamContent(stream, stream.Length, cancellationToken, progress);
 
@@ -2746,8 +2735,7 @@ namespace DecaTec.WebDav
             };
 
             SetHttpVersion(requestMethod);
-            var httpResponseMessage = await this.SendAsync(requestMethod, cancellationToken);
-            return new WebDavResponseMessage(httpResponseMessage);
+            return this.SendAsync(requestMethod, cancellationToken);
         }
 
         #endregion Upload file

--- a/DecaTec.WebDav/WebDavSession.cs
+++ b/DecaTec.WebDav/WebDavSession.cs
@@ -362,9 +362,9 @@ namespace DecaTec.WebDav
         /// <param name="sourceUrl">The source URL.</param>
         /// <param name="destinationUrl">The destination URL.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(string sourceUrl, string destinationUrl)
+        public Task<bool> CopyAsync(string sourceUrl, string destinationUrl, bool throwException = false)
         {
-            return await CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false);
+            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false, throwException);
         }
 
         /// <summary>
@@ -373,9 +373,9 @@ namespace DecaTec.WebDav
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUrl">The destination URL.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl)
+        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl, bool throwException = false)
         {
-            return await CopyAsync(itemToCopy, UriHelper.CreateUriFromUrl(destinationUrl), false);
+            return CopyAsync(itemToCopy, UriHelper.CreateUriFromUrl(destinationUrl), false, throwException);
         }
 
         /// <summary>
@@ -384,9 +384,9 @@ namespace DecaTec.WebDav
         /// <param name="sourceUri">The source <see cref="Uri"/>.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri)
+        public Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri, bool throwException = false)
         {
-            return await CopyAsync(sourceUri, destinationUri, false);
+            return CopyAsync(sourceUri, destinationUri, false, throwException);
         }
 
         /// <summary>
@@ -395,9 +395,9 @@ namespace DecaTec.WebDav
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri)
+        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri, bool throwException = false)
         {
-            return await CopyAsync(itemToCopy, destinationUri, false);
+            return CopyAsync(itemToCopy, destinationUri, false, throwException);
         }
 
         /// <summary>
@@ -407,9 +407,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUrl">The destination URL.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite)
+        public Task<bool> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite, bool throwException = false)
         {
-            return await CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite);
+            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, throwException);
         }
 
         /// <summary>
@@ -419,9 +419,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUrl">The destination URL.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl, bool overwrite)
+        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl, bool overwrite, bool throwException = false)
         {
-            return await CopyAsync(itemToCopy, UriHelper.CreateUriFromUrl(destinationUrl), overwrite);
+            return CopyAsync(itemToCopy, UriHelper.CreateUriFromUrl(destinationUrl), overwrite, throwException);
         }
 
         /// <summary>
@@ -431,9 +431,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri, bool overwrite)
+        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri, bool overwrite, bool throwException = false)
         {
-            return await CopyAsync(UriHelper.CombineUri(this.BaseUri, itemToCopy.Uri, true), destinationUri, overwrite);
+            return CopyAsync(UriHelper.CombineUri(this.BaseUri, itemToCopy.Uri, true), destinationUri, overwrite, throwException);
         }
 
         /// <summary>
@@ -443,12 +443,17 @@ namespace DecaTec.WebDav
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite)
+        public async Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite, bool throwException)
         {
             sourceUri = UriHelper.CombineUri(this.BaseUri, sourceUri, true);
             destinationUri = UriHelper.CombineUri(this.BaseUri, destinationUri, true);
             var lockToken = GetAffectedLockToken(destinationUri);
-            var response = await this.webDavClient.CopyAsync(sourceUri, destinationUri, overwrite, WebDavDepthHeaderValue.Infinity, lockToken);
+            var response = await webDavClient.CopyAsync(sourceUri, destinationUri, overwrite, WebDavDepthHeaderValue.Infinity, lockToken);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error copy file from '{sourceUri}' to '{destinationUri}'. Response: {response.ReasonPhrase}");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -461,9 +466,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the directory to create.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CreateDirectoryAsync(string url)
+        public Task<bool> CreateDirectoryAsync(string url, bool throwException = false)
         {
-            return await CreateDirectoryAsync(UriHelper.CreateUriFromUrl(url));
+            return CreateDirectoryAsync(UriHelper.CreateUriFromUrl(url), throwException);
         }
 
         /// <summary>
@@ -471,11 +476,16 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory to create.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CreateDirectoryAsync(Uri uri)
+        public async Task<bool> CreateDirectoryAsync(Uri uri, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.MkcolAsync(uri, lockToken);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error create directory '{uri}'. Response: {response.ReasonPhrase}");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -488,9 +498,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the directory or file to delete.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DeleteAsync(string url)
+        public Task<bool> DeleteAsync(string url, bool throwException = false)
         {
-            return await DeleteAsync(UriHelper.CreateUriFromUrl(url));
+            return DeleteAsync(UriHelper.CreateUriFromUrl(url), throwException);
         }
 
         /// <summary>
@@ -498,9 +508,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToDelete">The <see cref="WebDavSessionItem"/> to delete.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DeleteAsync(WebDavSessionItem itemToDelete)
+        public Task<bool> DeleteAsync(WebDavSessionItem itemToDelete, bool throwException = false)
         {
-            return await DeleteAsync(UriHelper.CombineUri(this.BaseUri, itemToDelete.Uri, true));
+            return DeleteAsync(UriHelper.CombineUri(this.BaseUri, itemToDelete.Uri, true), throwException);
         }
 
         /// <summary>
@@ -508,11 +518,16 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory or file to delete.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DeleteAsync(Uri uri)
+        public async Task<bool> DeleteAsync(Uri uri, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.DeleteAsync(uri, lockToken);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error delete '{uri}'. Response: {response.ReasonPhrase}");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -526,9 +541,9 @@ namespace DecaTec.WebDav
         /// <param name="url">The URL of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileAsync(string url, Stream localStream)
+        public Task<bool> DownloadFileAsync(string url, Stream localStream, bool throwException = false)
         {
-            return await DownloadFileAsync(UriHelper.CreateUriFromUrl(url), localStream);
+            return DownloadFileAsync(UriHelper.CreateUriFromUrl(url), localStream, throwException);
         }
 
         /// <summary>
@@ -537,9 +552,9 @@ namespace DecaTec.WebDav
         /// <param name="uri">The <see cref="Uri"/> of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileAsync(Uri uri, Stream localStream)
+        public Task<bool> DownloadFileAsync(Uri uri, Stream localStream, bool throwException = false)
         {
-            return await DownloadFileAsync(uri, localStream, CancellationToken.None);
+            return DownloadFileAsync(uri, localStream, CancellationToken.None, throwException);
         }
 
         /// <summary>
@@ -548,9 +563,9 @@ namespace DecaTec.WebDav
         /// <param name="itemToDownload">The <see cref="WebDavSessionItem"/> to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream)
+        public Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream, bool throwException = false)
         {
-            return await DownloadFileAsync(itemToDownload, localStream, CancellationToken.None);
+            return DownloadFileAsync(itemToDownload, localStream, CancellationToken.None, throwException);
         }
 
         /// <summary>
@@ -560,9 +575,9 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileAsync(string url, Stream localStream, CancellationToken ct)
+        public Task<bool> DownloadFileAsync(string url, Stream localStream, CancellationToken ct, bool throwException = false)
         {
-            return await DownloadFileAsync(UriHelper.CreateUriFromUrl(url), localStream, ct);
+            return DownloadFileAsync(UriHelper.CreateUriFromUrl(url), localStream, ct, throwException);
         }
 
         /// <summary>
@@ -572,9 +587,9 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream, CancellationToken ct)
+        public Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream, CancellationToken ct, bool throwException = false)
         {
-            return await DownloadFileAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, ct);
+            return DownloadFileAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, ct, throwException);
         }
 
         /// <summary>
@@ -584,10 +599,14 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileAsync(Uri uri, Stream localStream, CancellationToken ct)
+        public async Task<bool> DownloadFileAsync(Uri uri, Stream localStream, CancellationToken ct, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.GetAsync(uri, ct);
+            if ((!response.IsSuccessStatusCode || response.Content == null) && throwException)
+            {
+                throw new WebDavException($"Error download file '{uri}'. Response: {response.ReasonPhrase}");
+            }
 
             if (response.Content != null)
             {
@@ -597,8 +616,13 @@ namespace DecaTec.WebDav
                     await contentStream.CopyToAsync(localStream);
                     return true;
                 }
-                catch (IOException)
+                catch (IOException exception)
                 {
+                    if (throwException)
+                    {
+                        throw new WebDavException($"Error download file '{uri}'. Message: {exception.Message}", exception);
+                    }
+
                     return false;
                 }
             }
@@ -613,9 +637,9 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress)
+        public Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
         {
-            return await DownloadFileWithProgressAsync(url, localStream, progress, CancellationToken.None);
+            return DownloadFileWithProgressAsync(url, localStream, progress, CancellationToken.None, throwException);
         }
 
         /// <summary>
@@ -625,9 +649,9 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress)
+        public Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
         {
-            return await DownloadFileWithProgressAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, progress, CancellationToken.None);
+            return DownloadFileWithProgressAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, progress, CancellationToken.None, throwException);
         }
 
         /// <summary>
@@ -638,9 +662,9 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
+        public Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
         {
-            return await DownloadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), localStream, progress, cancellationToken);
+            return DownloadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), localStream, progress, cancellationToken, throwException);
         }
 
         /// <summary>
@@ -651,9 +675,9 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
+        public Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
         {
-            return await DownloadFileWithProgressAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, progress, cancellationToken);
+            return DownloadFileWithProgressAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, progress, cancellationToken, throwException);
         }
 
         /// <summary>
@@ -663,9 +687,9 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress)
+        public Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
         {
-            return await DownloadFileWithProgressAsync(uri, localStream, progress, CancellationToken.None);
+            return DownloadFileWithProgressAsync(uri, localStream, progress, CancellationToken.None, throwException);
         }
 
         /// <summary>
@@ -676,10 +700,15 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
+        public async Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.DownloadFileWithProgressAsync(uri, localStream, cancellationToken, progress);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error download file '{uri}'. Response: {response.ReasonPhrase}");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -692,9 +721,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL to check.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> ExistsAsync(string url)
+        public Task<bool> ExistsAsync(string url, bool throwException = false)
         {
-            return await ExistsAsync(UriHelper.CreateUriFromUrl(url));
+            return ExistsAsync(UriHelper.CreateUriFromUrl(url), throwException);
         }
 
         /// <summary>
@@ -702,10 +731,15 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> to check.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> ExistsAsync(Uri uri)
+        public async Task<bool> ExistsAsync(Uri uri, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.HeadAsync(uri);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error check exists '{uri}'. Response: {response.ReasonPhrase}");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -719,9 +753,9 @@ namespace DecaTec.WebDav
         /// <param name="item">The <see cref="WebDavSessionItem"/> to get the supported property names for.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
-        public async Task<string[]> GetSupportedPropertyNamesAsync(WebDavSessionItem item)
+        public async Task<string[]> GetSupportedPropertyNamesAsync(WebDavSessionItem item, bool throwException = false)
         {
-            return await GetSupportedPropertyNamesAsync(UriHelper.CombineUri(this.BaseUri, item.Uri, true));
+            return await GetSupportedPropertyNamesAsync(UriHelper.CombineUri(this.BaseUri, item.Uri, true), throwException);
         }
 
         /// <summary>
@@ -730,9 +764,9 @@ namespace DecaTec.WebDav
         /// <param name="url">The URL to get the supported property names for.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
-        public async Task<string[]> GetSupportedPropertyNamesAsync(string url)
+        public async Task<string[]> GetSupportedPropertyNamesAsync(string url, bool throwException = false)
         {
-            return await GetSupportedPropertyNamesAsync(UriHelper.CreateUriFromUrl(url));
+            return await GetSupportedPropertyNamesAsync(UriHelper.CreateUriFromUrl(url), throwException);
         }
 
         /// <summary>
@@ -741,11 +775,16 @@ namespace DecaTec.WebDav
         /// <param name="uri">The <see cref="Uri"/> to get the supported property names for.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
-        public async Task<string[]> GetSupportedPropertyNamesAsync(Uri uri)
+        public async Task<string[]> GetSupportedPropertyNamesAsync(Uri uri, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var propFind = PropFind.CreatePropFindWithPropName();
             var response = await this.webDavClient.PropFindAsync(uri, WebDavDepthHeaderValue.Zero, propFind);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error find property {uri}. Response {response.ReasonPhrase}.");
+            }
+
             var propertyNames = await WebDavHelper.GetPropertyNamesKnownAndUnknownFromMultiStatusContentAsync(response.Content);
 
             return propertyNames;
@@ -762,9 +801,9 @@ namespace DecaTec.WebDav
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
-        public async Task<IList<WebDavSessionItem>> ListAsync(Uri uri)
+        public Task<IList<WebDavSessionItem>> ListAsync(Uri uri)
         {
-            return await ListAsync(uri, PropFind.CreatePropFindAllProp());
+            return ListAsync(uri, PropFind.CreatePropFindAllProp());
         }
 
         /// <summary>
@@ -774,9 +813,9 @@ namespace DecaTec.WebDav
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
-        public async Task<IList<WebDavSessionItem>> ListAsync(string url)
+        public Task<IList<WebDavSessionItem>> ListAsync(string url)
         {
-            return await ListAsync(UriHelper.CreateUriFromUrl(url));
+            return ListAsync(UriHelper.CreateUriFromUrl(url));
         }
 
         /// <summary>
@@ -786,9 +825,9 @@ namespace DecaTec.WebDav
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
-        public async Task<IList<WebDavSessionItem>> ListAsync(WebDavSessionItem item)
+        public Task<IList<WebDavSessionItem>> ListAsync(WebDavSessionItem item)
         {
-            return await ListAsync(UriHelper.CombineUri(this.BaseUri, item.Uri, true));
+            return ListAsync(UriHelper.CombineUri(this.BaseUri, item.Uri, true));
         }
 
         /// <summary>
@@ -797,9 +836,9 @@ namespace DecaTec.WebDav
         /// <param name="url">The URL of the directory which content should be listed. Has to be an absolute URL (including the base URL) or a relative URL (relative to base URL).</param>
         /// <param name="propFind">The <see cref="PropFind"/> to use. Different PropFind  types can be created using the static methods of the class <see cref="PropFind"/>.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<IList<WebDavSessionItem>> ListAsync(string url, PropFind propFind)
+        public Task<IList<WebDavSessionItem>> ListAsync(string url, PropFind propFind)
         {
-            return await ListAsync(UriHelper.CreateUriFromUrl(url), propFind);
+            return ListAsync(UriHelper.CreateUriFromUrl(url), propFind);
         }
 
         /// <summary>
@@ -808,9 +847,9 @@ namespace DecaTec.WebDav
         /// <param name="item">The <see cref="WebDavSessionItem"/> which content should be listed. Has to be an absolute URI (including the base URI) or a relative URI (relative to base URI).</param>
         /// <param name="propFind">The <see cref="PropFind"/> to use. Different PropFind  types can be created using the static methods of the class <see cref="PropFind"/>.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<IList<WebDavSessionItem>> ListAsync(WebDavSessionItem item, PropFind propFind)
+        public Task<IList<WebDavSessionItem>> ListAsync(WebDavSessionItem item, PropFind propFind)
         {
-            return await ListAsync(UriHelper.CombineUri(this.BaseUri, item.Uri, true), propFind);
+            return ListAsync(UriHelper.CombineUri(this.BaseUri, item.Uri, true), propFind);
         }
 
         /// <summary>
@@ -972,9 +1011,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the file or directory to lock.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> LockAsync(string url)
+        public Task<bool> LockAsync(string url, bool throwException = false)
         {
-            return await LockAsync(UriHelper.CreateUriFromUrl(url));
+            return LockAsync(UriHelper.CreateUriFromUrl(url), throwException);
         }
 
         /// <summary>
@@ -982,9 +1021,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToLock">The <see cref="WebDavSessionItem"/> to lock.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> LockAsync(WebDavSessionItem itemToLock)
+        public Task<bool> LockAsync(WebDavSessionItem itemToLock, bool throwException = false)
         {
-            return await LockAsync(UriHelper.CombineUri(this.BaseUri, itemToLock.Uri, true));
+            return LockAsync(UriHelper.CombineUri(this.BaseUri, itemToLock.Uri, true), throwException);
         }
 
         /// <summary>
@@ -992,7 +1031,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The URI of the file or directory to lock.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> LockAsync(Uri uri)
+        public async Task<bool> LockAsync(Uri uri, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
 
@@ -1037,6 +1076,11 @@ namespace DecaTec.WebDav
             if (!this.permanentLocks.TryAdd(uri, permanentLock))
                 throw new WebDavException("Lock with lock root " + uri.ToString() + " already exists.");
 
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error lock {uri}. Response {response.ReasonPhrase}.");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -1050,9 +1094,9 @@ namespace DecaTec.WebDav
         /// <param name="sourceUrl">The URL of the source.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(string sourceUrl, string destinationUrl)
+        public Task<bool> MoveAsync(string sourceUrl, string destinationUrl, bool throwException = false)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false, throwException);
         }
 
         /// <summary>
@@ -1061,9 +1105,9 @@ namespace DecaTec.WebDav
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl)
+        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl, bool throwException = false)
         {
-            return await MoveAsync(itemToMove, destinationUrl);
+            return MoveAsync(itemToMove, destinationUrl, throwException);
         }
 
         /// <summary>
@@ -1072,9 +1116,9 @@ namespace DecaTec.WebDav
         /// <param name="sourceUri">The URI of the source.</param>
         /// <param name="destinationUri">The URL of the destination.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri)
+        public Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri, bool throwException = false)
         {
-            return await MoveAsync(sourceUri, destinationUri, false);
+            return MoveAsync(sourceUri, destinationUri, false, throwException);
         }
 
         /// <summary>
@@ -1083,9 +1127,9 @@ namespace DecaTec.WebDav
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUri">The URL of the destination.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri)
+        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri, bool throwException = false)
         {
-            return await MoveAsync(itemToMove, destinationUri, false);
+            return MoveAsync(itemToMove, destinationUri, false, throwException);
         }
 
         /// <summary>
@@ -1095,9 +1139,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUrl">The URL of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite)
+        public Task<bool> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, bool throwException = false)
         {
-            return await MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, throwException);
         }
 
         /// <summary>
@@ -1107,9 +1151,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUrl">The URL of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl, bool overwrite)
+        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl, bool overwrite, bool throwException = false)
         {
-            return await MoveAsync(itemToMove, UriHelper.CreateUriFromUrl(destinationUrl), overwrite);
+            return MoveAsync(itemToMove, UriHelper.CreateUriFromUrl(destinationUrl), overwrite, throwException);
         }
 
         /// <summary>
@@ -1119,9 +1163,9 @@ namespace DecaTec.WebDav
         /// <param name="destinationUri">The <see cref="Uri"/> of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri, bool overwrite)
+        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri, bool overwrite, bool throwException = false)
         {
-            return await MoveAsync(UriHelper.CombineUri(this.BaseUri, itemToMove.Uri, true), destinationUri, overwrite);
+            return MoveAsync(UriHelper.CombineUri(this.BaseUri, itemToMove.Uri, true), destinationUri, overwrite);
         }
 
         /// <summary>
@@ -1131,13 +1175,18 @@ namespace DecaTec.WebDav
         /// <param name="destinationUri">The <see cref="Uri"/> of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite)
+        public async Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, bool throwException)
         {
             sourceUri = UriHelper.CombineUri(this.BaseUri, sourceUri, true);
             destinationUri = UriHelper.CombineUri(this.BaseUri, destinationUri, true);
             var lockTokenSource = GetAffectedLockToken(sourceUri);
             var lockTokenDestination = GetAffectedLockToken(destinationUri);
             var response = await this.webDavClient.MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error move file from {sourceUri} to {destinationUri}. Response {response.ReasonPhrase}.");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -1223,9 +1272,9 @@ namespace DecaTec.WebDav
         /// <param name="url">The URL of the file to upload.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileAsync(string url, Stream localStream)
+        public Task<bool> UploadFileAsync(string url, Stream localStream, bool throwException = false)
         {
-            return await UploadFileAsync(UriHelper.CreateUriFromUrl(url), localStream);
+            return UploadFileAsync(UriHelper.CreateUriFromUrl(url), localStream, throwException);
         }
 
         /// <summary>
@@ -1235,13 +1284,13 @@ namespace DecaTec.WebDav
         /// <param name="fileName">The file name of the uploaded file.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream localStream)
+        public Task<bool> UploadFileAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream localStream, bool throwException = false)
         {
             if (!(folderToUploadTo.IsFolder ?? false))
                 throw new WebDavException("The upload target is no folder.");
 
             var uploadUrl = UriHelper.CombineUriAndUrl(folderToUploadTo.Uri, fileName, true);
-            return await UploadFileAsync(uploadUrl, localStream);
+            return UploadFileAsync(uploadUrl, localStream, throwException);
         }
 
         /// <summary>
@@ -1250,12 +1299,17 @@ namespace DecaTec.WebDav
         /// <param name="uri">The <see cref="Uri"/> of the file to upload.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileAsync(Uri uri, Stream localStream)
+        public async Task<bool> UploadFileAsync(Uri uri, Stream localStream, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var content = new StreamContent(localStream);
             var response = await this.webDavClient.PutAsync(uri, content, lockToken);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error upload file {uri}. Response {response.ReasonPhrase}.");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -1267,9 +1321,9 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress)
+        public Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
         {
-            return await UploadFileWithProgressAsync(url, stream, contentType, progress, CancellationToken.None);
+            return UploadFileWithProgressAsync(url, stream, contentType, progress, CancellationToken.None, throwException);
         }
 
         /// <summary>
@@ -1280,9 +1334,9 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress)
+        public Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
         {
-            return await UploadFileWithProgressAsync(uri, stream, contentType, progress, CancellationToken.None);
+            return UploadFileWithProgressAsync(uri, stream, contentType, progress, CancellationToken.None, throwException);
         }
 
         /// <summary>
@@ -1294,9 +1348,9 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress)
+        public Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
         {
-            return await UploadFileWithProgressAsync(folderToUploadTo, fileName, stream, contentType, progress, CancellationToken.None);
+            return UploadFileWithProgressAsync(folderToUploadTo, fileName, stream, contentType, progress, CancellationToken.None, throwException);
         }
 
         /// <summary>
@@ -1308,9 +1362,9 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
+        public Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
         {
-            return await UploadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), stream, contentType, progress, cancellationToken);
+            return UploadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), stream, contentType, progress, cancellationToken, throwException);
         }
 
         /// <summary>
@@ -1323,13 +1377,13 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
+        public Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
         {
             if (!(folderToUploadTo.IsFolder ?? false))
                 throw new WebDavException("The upload target is no folder.");
 
             var uploadUrl = UriHelper.CombineUrl(folderToUploadTo.Uri.ToString(), fileName, true);
-            return await UploadFileWithProgressAsync(uploadUrl, stream, contentType, progress, cancellationToken);
+            return UploadFileWithProgressAsync(uploadUrl, stream, contentType, progress, cancellationToken, throwException);
         }
 
         /// <summary>
@@ -1341,11 +1395,16 @@ namespace DecaTec.WebDav
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
+        public async Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.UploadFileWithProgressAsync(uri, stream, contentType, progress, cancellationToken, lockToken);
+            if (!response.IsSuccessStatusCode && throwException)
+            {
+                throw new WebDavException($"Error upload file {uri}. Response {response.ReasonPhrase}");
+            }
+
             return response.IsSuccessStatusCode;
         }
 
@@ -1358,9 +1417,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the file or directory to unlock.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UnlockAsync(string url)
+        public Task<bool> UnlockAsync(string url)
         {
-            return await UnlockAsync(UriHelper.CreateUriFromUrl(url));
+            return UnlockAsync(UriHelper.CreateUriFromUrl(url));
         }
 
         /// <summary>
@@ -1368,9 +1427,9 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToUnlock">The <see cref="WebDavSessionItem"/> to unlock.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UnlockAsync(WebDavSessionItem itemToUnlock)
+        public Task<bool> UnlockAsync(WebDavSessionItem itemToUnlock)
         {
-            return await UnlockAsync(UriHelper.CombineUri(this.BaseUri, itemToUnlock.Uri, true));
+            return UnlockAsync(UriHelper.CombineUri(this.BaseUri, itemToUnlock.Uri, true));
         }
 
         /// <summary>

--- a/DecaTec.WebDav/WebDavSession.cs
+++ b/DecaTec.WebDav/WebDavSession.cs
@@ -350,6 +350,16 @@ namespace DecaTec.WebDav
             set;
         }
 
+        /// <summary>
+        /// Gets or sets how <see cref="WebDavSession"/> processing error response from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.
+        /// </summary>
+        public bool ThrowException
+        {
+            get;
+            set;
+        }
+        
         #endregion Properties
 
         #region Public methods
@@ -361,11 +371,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="sourceUrl">The source URL.</param>
         /// <param name="destinationUrl">The destination URL.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> CopyAsync(string sourceUrl, string destinationUrl, bool throwException = false)
+        public Task<bool> CopyAsync(string sourceUrl, string destinationUrl)
         {
-            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false, throwException);
+            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false);
         }
 
         /// <summary>
@@ -373,11 +382,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUrl">The destination URL.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl, bool throwException = false)
+        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl)
         {
-            return CopyAsync(itemToCopy, UriHelper.CreateUriFromUrl(destinationUrl), false, throwException);
+            return CopyAsync(itemToCopy, UriHelper.CreateUriFromUrl(destinationUrl), false);
         }
 
         /// <summary>
@@ -385,11 +393,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="sourceUri">The source <see cref="Uri"/>.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri, bool throwException = false)
+        public Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri)
         {
-            return CopyAsync(sourceUri, destinationUri, false, throwException);
+            return CopyAsync(sourceUri, destinationUri, false);
         }
 
         /// <summary>
@@ -397,11 +404,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri, bool throwException = false)
+        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri)
         {
-            return CopyAsync(itemToCopy, destinationUri, false, throwException);
+            return CopyAsync(itemToCopy, destinationUri, false);
         }
 
         /// <summary>
@@ -410,11 +416,10 @@ namespace DecaTec.WebDav
         /// <param name="sourceUrl">The source URL.</param>
         /// <param name="destinationUrl">The destination URL.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite, bool throwException = false)
+        public Task<bool> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite)
         {
-            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, throwException);
+            return CopyAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite);
         }
 
         /// <summary>
@@ -423,11 +428,10 @@ namespace DecaTec.WebDav
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUrl">The destination URL.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl, bool overwrite, bool throwException = false)
+        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl, bool overwrite)
         {
-            return CopyAsync(itemToCopy, UriHelper.CreateUriFromUrl(destinationUrl), overwrite, throwException);
+            return CopyAsync(itemToCopy, UriHelper.CreateUriFromUrl(destinationUrl), overwrite);
         }
 
         /// <summary>
@@ -436,11 +440,10 @@ namespace DecaTec.WebDav
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri, bool overwrite, bool throwException = false)
+        public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri, bool overwrite)
         {
-            return CopyAsync(UriHelper.CombineUri(this.BaseUri, itemToCopy.Uri, true), destinationUri, overwrite, throwException);
+            return CopyAsync(UriHelper.CombineUri(this.BaseUri, itemToCopy.Uri, true), destinationUri, overwrite);
         }
 
         /// <summary>
@@ -449,15 +452,14 @@ namespace DecaTec.WebDav
         /// <param name="sourceUri">The source <see cref="Uri"/>.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite, bool throwException)
+        public async Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite)
         {
             sourceUri = UriHelper.CombineUri(this.BaseUri, sourceUri, true);
             destinationUri = UriHelper.CombineUri(this.BaseUri, destinationUri, true);
             var lockToken = GetAffectedLockToken(destinationUri);
             var response = await webDavClient.CopyAsync(sourceUri, destinationUri, overwrite, WebDavDepthHeaderValue.Infinity, lockToken);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error copy file from '{sourceUri}' to '{destinationUri}'. Response: {response.ReasonPhrase}");
             }
@@ -473,25 +475,23 @@ namespace DecaTec.WebDav
         /// Creates a directory at the URL specified.
         /// </summary>
         /// <param name="url">The URL of the directory to create.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> CreateDirectoryAsync(string url, bool throwException = false)
+        public Task<bool> CreateDirectoryAsync(string url)
         {
-            return CreateDirectoryAsync(UriHelper.CreateUriFromUrl(url), throwException);
+            return CreateDirectoryAsync(UriHelper.CreateUriFromUrl(url));
         }
 
         /// <summary>
         /// Creates a directory at the <see cref="Uri"/> specified.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory to create.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> CreateDirectoryAsync(Uri uri, bool throwException)
+        public async Task<bool> CreateDirectoryAsync(Uri uri)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.MkcolAsync(uri, lockToken);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error create directory '{uri}'. Response: {response.ReasonPhrase}");
             }
@@ -507,36 +507,33 @@ namespace DecaTec.WebDav
         /// Deletes a directory or file at the URL specified.
         /// </summary>
         /// <param name="url">The URL of the directory or file to delete.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DeleteAsync(string url, bool throwException = false)
+        public Task<bool> DeleteAsync(string url)
         {
-            return DeleteAsync(UriHelper.CreateUriFromUrl(url), throwException);
+            return DeleteAsync(UriHelper.CreateUriFromUrl(url));
         }
 
         /// <summary>
         /// Deletes a directory or file specified by a <see cref="WebDavSessionItem"/>.
         /// </summary>
         /// <param name="itemToDelete">The <see cref="WebDavSessionItem"/> to delete.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DeleteAsync(WebDavSessionItem itemToDelete, bool throwException = false)
+        public Task<bool> DeleteAsync(WebDavSessionItem itemToDelete)
         {
-            return DeleteAsync(UriHelper.CombineUri(this.BaseUri, itemToDelete.Uri, true), throwException);
+            return DeleteAsync(UriHelper.CombineUri(this.BaseUri, itemToDelete.Uri, true));
         }
 
         /// <summary>
         /// Deletes a directory or file at the <see cref="Uri"/> specified.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory or file to delete.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DeleteAsync(Uri uri, bool throwException)
+        public async Task<bool> DeleteAsync(Uri uri)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.DeleteAsync(uri, lockToken);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error delete '{uri}'. Response: {response.ReasonPhrase}");
             }
@@ -553,11 +550,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileAsync(string url, Stream localStream, bool throwException = false)
+        public Task<bool> DownloadFileAsync(string url, Stream localStream)
         {
-            return DownloadFileAsync(UriHelper.CreateUriFromUrl(url), localStream, throwException);
+            return DownloadFileAsync(UriHelper.CreateUriFromUrl(url), localStream);
         }
 
         /// <summary>
@@ -565,11 +561,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileAsync(Uri uri, Stream localStream, bool throwException = false)
+        public Task<bool> DownloadFileAsync(Uri uri, Stream localStream)
         {
-            return DownloadFileAsync(uri, localStream, CancellationToken.None, throwException);
+            return DownloadFileAsync(uri, localStream, CancellationToken.None);
         }
 
         /// <summary>
@@ -577,11 +572,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToDownload">The <see cref="WebDavSessionItem"/> to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream, bool throwException = false)
+        public Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream)
         {
-            return DownloadFileAsync(itemToDownload, localStream, CancellationToken.None, throwException);
+            return DownloadFileAsync(itemToDownload, localStream, CancellationToken.None);
         }
 
         /// <summary>
@@ -590,11 +584,10 @@ namespace DecaTec.WebDav
         /// <param name="url">The URL of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileAsync(string url, Stream localStream, CancellationToken ct, bool throwException = false)
+        public Task<bool> DownloadFileAsync(string url, Stream localStream, CancellationToken ct)
         {
-            return DownloadFileAsync(UriHelper.CreateUriFromUrl(url), localStream, ct, throwException);
+            return DownloadFileAsync(UriHelper.CreateUriFromUrl(url), localStream, ct);
         }
 
         /// <summary>
@@ -603,11 +596,10 @@ namespace DecaTec.WebDav
         /// <param name="itemToDownload">The <see cref="WebDavSessionItem"/> to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream, CancellationToken ct, bool throwException = false)
+        public Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream, CancellationToken ct)
         {
-            return DownloadFileAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, ct, throwException);
+            return DownloadFileAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, ct);
         }
 
         /// <summary>
@@ -616,13 +608,12 @@ namespace DecaTec.WebDav
         /// <param name="uri">The <see cref="Uri"/> of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileAsync(Uri uri, Stream localStream, CancellationToken ct, bool throwException)
+        public async Task<bool> DownloadFileAsync(Uri uri, Stream localStream, CancellationToken ct)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.GetAsync(uri, ct);
-            if ((!response.IsSuccessStatusCode || response.Content == null) && throwException)
+            if ((!response.IsSuccessStatusCode || response.Content == null) && ThrowException)
             {
                 throw new WebDavException($"Error download file '{uri}'. Response: {response.ReasonPhrase}");
             }
@@ -637,7 +628,7 @@ namespace DecaTec.WebDav
                 }
                 catch (IOException exception)
                 {
-                    if (throwException)
+                    if (ThrowException)
                     {
                         throw new WebDavException($"Error download file '{uri}'. Message: {exception.Message}", exception);
                     }
@@ -655,11 +646,10 @@ namespace DecaTec.WebDav
         /// <param name="url">Te URL of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
+        public Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress)
         {
-            return DownloadFileWithProgressAsync(url, localStream, progress, CancellationToken.None, throwException);
+            return DownloadFileWithProgressAsync(url, localStream, progress, CancellationToken.None);
         }
 
         /// <summary>
@@ -668,11 +658,10 @@ namespace DecaTec.WebDav
         /// <param name="itemToDownload">The <see cref="WebDavSessionItem"/> to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
+        public Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress)
         {
-            return DownloadFileWithProgressAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, progress, CancellationToken.None, throwException);
+            return DownloadFileWithProgressAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, progress, CancellationToken.None);
         }
 
         /// <summary>
@@ -682,11 +671,10 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
+        public Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
         {
-            return DownloadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), localStream, progress, cancellationToken, throwException);
+            return DownloadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), localStream, progress, cancellationToken);
         }
 
         /// <summary>
@@ -696,11 +684,10 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
+        public Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
         {
-            return DownloadFileWithProgressAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, progress, cancellationToken, throwException);
+            return DownloadFileWithProgressAsync(UriHelper.CombineUri(this.BaseUri, itemToDownload.Uri, true), localStream, progress, cancellationToken);
         }
 
         /// <summary>
@@ -709,11 +696,10 @@ namespace DecaTec.WebDav
         /// <param name="uri">Te <see cref="Uri"/> of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
+        public Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress)
         {
-            return DownloadFileWithProgressAsync(uri, localStream, progress, CancellationToken.None, throwException);
+            return DownloadFileWithProgressAsync(uri, localStream, progress, CancellationToken.None);
         }
 
         /// <summary>
@@ -723,13 +709,12 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException)
+        public async Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.DownloadFileWithProgressAsync(uri, localStream, cancellationToken, progress);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error download file '{uri}'. Response: {response.ReasonPhrase}");
             }
@@ -745,24 +730,22 @@ namespace DecaTec.WebDav
         /// Checks if a file or directory exists at the URL specified.
         /// </summary>
         /// <param name="url">The URL to check.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> ExistsAsync(string url, bool throwException = false)
+        public Task<bool> ExistsAsync(string url)
         {
-            return ExistsAsync(UriHelper.CreateUriFromUrl(url), throwException);
+            return ExistsAsync(UriHelper.CreateUriFromUrl(url));
         }
 
         /// <summary>
         /// Checks if a file or directory exists at the <see cref="Uri"/> specified.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> to check.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> ExistsAsync(Uri uri, bool throwException)
+        public async Task<bool> ExistsAsync(Uri uri)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.HeadAsync(uri);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error check exists '{uri}'. Response: {response.ReasonPhrase}");
             }
@@ -778,39 +761,36 @@ namespace DecaTec.WebDav
         /// Gets the WebDAV property names which are supported by the WebDAV server for the given <see cref="WebDavSessionItem"/>.
         /// </summary>
         /// <param name="item">The <see cref="WebDavSessionItem"/> to get the supported property names for.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
-        public async Task<string[]> GetSupportedPropertyNamesAsync(WebDavSessionItem item, bool throwException = false)
+        public async Task<string[]> GetSupportedPropertyNamesAsync(WebDavSessionItem item)
         {
-            return await GetSupportedPropertyNamesAsync(UriHelper.CombineUri(this.BaseUri, item.Uri, true), throwException);
+            return await GetSupportedPropertyNamesAsync(UriHelper.CombineUri(this.BaseUri, item.Uri, true));
         }
 
         /// <summary>
         /// Gets the WebDAV property names which are supported by the WebDAV server for the element at the given URL.
         /// </summary>
         /// <param name="url">The URL to get the supported property names for.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
-        public async Task<string[]> GetSupportedPropertyNamesAsync(string url, bool throwException = false)
+        public async Task<string[]> GetSupportedPropertyNamesAsync(string url)
         {
-            return await GetSupportedPropertyNamesAsync(UriHelper.CreateUriFromUrl(url), throwException);
+            return await GetSupportedPropertyNamesAsync(UriHelper.CreateUriFromUrl(url));
         }
 
         /// <summary>
         /// Gets the WebDAV property names which are supported by the WebDAV server for the element at the given <see cref="Uri"/>.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> to get the supported property names for.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
-        public async Task<string[]> GetSupportedPropertyNamesAsync(Uri uri, bool throwException)
+        public async Task<string[]> GetSupportedPropertyNamesAsync(Uri uri)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var propFind = PropFind.CreatePropFindWithPropName();
             var response = await this.webDavClient.PropFindAsync(uri, WebDavDepthHeaderValue.Zero, propFind);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error find property {uri}. Response {response.ReasonPhrase}.");
             }
@@ -828,7 +808,6 @@ namespace DecaTec.WebDav
         /// Retrieves a list of files and directories of the directory at the <see cref="Uri"/> specified (using 'allprop').
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory which content should be listed. Has to be an absolute URI (including the base URI) or a relative URI (relative to base URI).</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
@@ -841,7 +820,6 @@ namespace DecaTec.WebDav
         /// Retrieves a list of files and directories of the directory at the URL specified.
         /// </summary>
         /// <param name="url">The URL of the directory which content should be listed. Has to be an absolute URL (including the base URL) or a relative URL (relative to base URL).</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
@@ -854,7 +832,6 @@ namespace DecaTec.WebDav
         /// Retrieves a list of files and directories of the directory from the <see cref="WebDavSessionItem"/> specified
         /// </summary>
         /// <param name="item">The <see cref="WebDavSessionItem"/> which content should be listed.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
@@ -868,7 +845,6 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the directory which content should be listed. Has to be an absolute URL (including the base URL) or a relative URL (relative to base URL).</param>
         /// <param name="propFind">The <see cref="PropFind"/> to use. Different PropFind  types can be created using the static methods of the class <see cref="PropFind"/>.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<IList<WebDavSessionItem>> ListAsync(string url, PropFind propFind)
         {
@@ -880,7 +856,6 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="item">The <see cref="WebDavSessionItem"/> which content should be listed. Has to be an absolute URI (including the base URI) or a relative URI (relative to base URI).</param>
         /// <param name="propFind">The <see cref="PropFind"/> to use. Different PropFind  types can be created using the static methods of the class <see cref="PropFind"/>.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<IList<WebDavSessionItem>> ListAsync(WebDavSessionItem item, PropFind propFind)
         {
@@ -892,7 +867,6 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory which content should be listed. Has to be an absolute URI (including the base URI) or a relative URI (relative to base URI).</param>
         /// <param name="propFind">The <see cref="PropFind"/> to use. Different PropFind  types can be created using the static methods of the class <see cref="PropFind"/>.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<IList<WebDavSessionItem>> ListAsync(Uri uri, PropFind propFind)
         {
@@ -1046,31 +1020,28 @@ namespace DecaTec.WebDav
         /// Locks a file or directory at the URL specified.
         /// </summary>
         /// <param name="url">The URL of the file or directory to lock.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> LockAsync(string url, bool throwException = false)
+        public Task<bool> LockAsync(string url)
         {
-            return LockAsync(UriHelper.CreateUriFromUrl(url), throwException);
+            return LockAsync(UriHelper.CreateUriFromUrl(url));
         }
 
         /// <summary>
         ///  Locks a file or directory specified as <see cref="WebDavSessionItem"/>.
         /// </summary>
         /// <param name="itemToLock">The <see cref="WebDavSessionItem"/> to lock.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> LockAsync(WebDavSessionItem itemToLock, bool throwException = false)
+        public Task<bool> LockAsync(WebDavSessionItem itemToLock)
         {
-            return LockAsync(UriHelper.CombineUri(this.BaseUri, itemToLock.Uri, true), throwException);
+            return LockAsync(UriHelper.CombineUri(this.BaseUri, itemToLock.Uri, true));
         }
 
         /// <summary>
         ///  Locks a file or directory at the URL specified.
         /// </summary>
         /// <param name="uri">The URI of the file or directory to lock.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> LockAsync(Uri uri, bool throwException)
+        public async Task<bool> LockAsync(Uri uri)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
 
@@ -1115,7 +1086,7 @@ namespace DecaTec.WebDav
             if (!this.permanentLocks.TryAdd(uri, permanentLock))
                 throw new WebDavException("Lock with lock root " + uri.ToString() + " already exists.");
 
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error lock {uri}. Response {response.ReasonPhrase}.");
             }
@@ -1132,11 +1103,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="sourceUrl">The URL of the source.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> MoveAsync(string sourceUrl, string destinationUrl, bool throwException = false)
+        public Task<bool> MoveAsync(string sourceUrl, string destinationUrl)
         {
-            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false, throwException);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), false);
         }
 
         /// <summary>
@@ -1144,11 +1114,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl, bool throwException = false)
+        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl)
         {
-            return MoveAsync(itemToMove, destinationUrl, throwException);
+            return MoveAsync(itemToMove, destinationUrl);
         }
 
         /// <summary>
@@ -1156,11 +1125,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="sourceUri">The URI of the source.</param>
         /// <param name="destinationUri">The URL of the destination.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri, bool throwException = false)
+        public Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri)
         {
-            return MoveAsync(sourceUri, destinationUri, false, throwException);
+            return MoveAsync(sourceUri, destinationUri, false);
         }
 
         /// <summary>
@@ -1168,11 +1136,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUri">The URL of the destination.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri, bool throwException = false)
+        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri)
         {
-            return MoveAsync(itemToMove, destinationUri, false, throwException);
+            return MoveAsync(itemToMove, destinationUri, false);
         }
 
         /// <summary>
@@ -1181,11 +1148,10 @@ namespace DecaTec.WebDav
         /// <param name="sourceUrl">The URL of the source.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, bool throwException = false)
+        public Task<bool> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite)
         {
-            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite, throwException);
+            return MoveAsync(UriHelper.CreateUriFromUrl(sourceUrl), UriHelper.CreateUriFromUrl(destinationUrl), overwrite);
         }
 
         /// <summary>
@@ -1194,11 +1160,10 @@ namespace DecaTec.WebDav
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl, bool overwrite, bool throwException = false)
+        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl, bool overwrite)
         {
-            return MoveAsync(itemToMove, UriHelper.CreateUriFromUrl(destinationUrl), overwrite, throwException);
+            return MoveAsync(itemToMove, UriHelper.CreateUriFromUrl(destinationUrl), overwrite);
         }
 
         /// <summary>
@@ -1207,9 +1172,8 @@ namespace DecaTec.WebDav
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUri">The <see cref="Uri"/> of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri, bool overwrite, bool throwException = false)
+        public Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri, bool overwrite)
         {
             return MoveAsync(UriHelper.CombineUri(this.BaseUri, itemToMove.Uri, true), destinationUri, overwrite);
         }
@@ -1220,16 +1184,15 @@ namespace DecaTec.WebDav
         /// <param name="sourceUri">The <see cref="Uri"/> of the source.</param>
         /// <param name="destinationUri">The <see cref="Uri"/> of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, bool throwException)
+        public async Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite)
         {
             sourceUri = UriHelper.CombineUri(this.BaseUri, sourceUri, true);
             destinationUri = UriHelper.CombineUri(this.BaseUri, destinationUri, true);
             var lockTokenSource = GetAffectedLockToken(sourceUri);
             var lockTokenDestination = GetAffectedLockToken(destinationUri);
             var response = await this.webDavClient.MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error move file from {sourceUri} to {destinationUri}. Response {response.ReasonPhrase}.");
             }
@@ -1318,11 +1281,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the file to upload.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> UploadFileAsync(string url, Stream localStream, bool throwException = false)
+        public Task<bool> UploadFileAsync(string url, Stream localStream)
         {
-            return UploadFileAsync(UriHelper.CreateUriFromUrl(url), localStream, throwException);
+            return UploadFileAsync(UriHelper.CreateUriFromUrl(url), localStream);
         }
 
         /// <summary>
@@ -1331,15 +1293,14 @@ namespace DecaTec.WebDav
         /// <param name="folderToUploadTo">The folder as <see cref="WebDavSessionItem"/> to upload to.</param>
         /// <param name="fileName">The file name of the uploaded file.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> UploadFileAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream localStream, bool throwException = false)
+        public Task<bool> UploadFileAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream localStream)
         {
             if (!(folderToUploadTo.IsFolder ?? false))
                 throw new WebDavException("The upload target is no folder.");
 
             var uploadUrl = UriHelper.CombineUriAndUrl(folderToUploadTo.Uri, fileName, true);
-            return UploadFileAsync(uploadUrl, localStream, throwException);
+            return UploadFileAsync(uploadUrl, localStream);
         }
 
         /// <summary>
@@ -1347,15 +1308,14 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the file to upload.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileAsync(Uri uri, Stream localStream, bool throwException)
+        public async Task<bool> UploadFileAsync(Uri uri, Stream localStream)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var content = new StreamContent(localStream);
             var response = await this.webDavClient.PutAsync(uri, content, lockToken);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error upload file {uri}. Response {response.ReasonPhrase}.");
             }
@@ -1370,11 +1330,10 @@ namespace DecaTec.WebDav
         /// <param name="stream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
+        public Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress)
         {
-            return UploadFileWithProgressAsync(url, stream, contentType, progress, CancellationToken.None, throwException);
+            return UploadFileWithProgressAsync(url, stream, contentType, progress, CancellationToken.None);
         }
 
         /// <summary>
@@ -1384,11 +1343,10 @@ namespace DecaTec.WebDav
         /// <param name="stream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
+        public Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress)
         {
-            return UploadFileWithProgressAsync(uri, stream, contentType, progress, CancellationToken.None, throwException);
+            return UploadFileWithProgressAsync(uri, stream, contentType, progress, CancellationToken.None);
         }
 
         /// <summary>
@@ -1399,11 +1357,10 @@ namespace DecaTec.WebDav
         /// <param name="stream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
+        public Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress)
         {
-            return UploadFileWithProgressAsync(folderToUploadTo, fileName, stream, contentType, progress, CancellationToken.None, throwException);
+            return UploadFileWithProgressAsync(folderToUploadTo, fileName, stream, contentType, progress, CancellationToken.None);
         }
 
         /// <summary>
@@ -1414,11 +1371,10 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
+        public Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
         {
-            return UploadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), stream, contentType, progress, cancellationToken, throwException);
+            return UploadFileWithProgressAsync(UriHelper.CreateUriFromUrl(url), stream, contentType, progress, cancellationToken);
         }
 
         /// <summary>
@@ -1430,15 +1386,14 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
+        public Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
         {
             if (!(folderToUploadTo.IsFolder ?? false))
                 throw new WebDavException("The upload target is no folder.");
 
             var uploadUrl = UriHelper.CombineUrl(folderToUploadTo.Uri.ToString(), fileName, true);
-            return UploadFileWithProgressAsync(uploadUrl, stream, contentType, progress, cancellationToken, throwException);
+            return UploadFileWithProgressAsync(uploadUrl, stream, contentType, progress, cancellationToken);
         }
 
         /// <summary>
@@ -1449,14 +1404,13 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException)
+        public async Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken)
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.UploadFileWithProgressAsync(uri, stream, contentType, progress, cancellationToken, lockToken);
-            if (!response.IsSuccessStatusCode && throwException)
+            if (!response.IsSuccessStatusCode && ThrowException)
             {
                 throw new WebDavException($"Error upload file {uri}. Response {response.ReasonPhrase}");
             }

--- a/DecaTec.WebDav/WebDavSession.cs
+++ b/DecaTec.WebDav/WebDavSession.cs
@@ -361,6 +361,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="sourceUrl">The source URL.</param>
         /// <param name="destinationUrl">The destination URL.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> CopyAsync(string sourceUrl, string destinationUrl, bool throwException = false)
         {
@@ -372,6 +373,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUrl">The destination URL.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl, bool throwException = false)
         {
@@ -383,6 +385,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="sourceUri">The source <see cref="Uri"/>.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri, bool throwException = false)
         {
@@ -394,6 +397,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri, bool throwException = false)
         {
@@ -406,6 +410,7 @@ namespace DecaTec.WebDav
         /// <param name="sourceUrl">The source URL.</param>
         /// <param name="destinationUrl">The destination URL.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> CopyAsync(string sourceUrl, string destinationUrl, bool overwrite, bool throwException = false)
         {
@@ -418,6 +423,7 @@ namespace DecaTec.WebDav
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUrl">The destination URL.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, string destinationUrl, bool overwrite, bool throwException = false)
         {
@@ -430,6 +436,7 @@ namespace DecaTec.WebDav
         /// <param name="itemToCopy">The <see cref="WebDavSessionItem"/> to copy.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> CopyAsync(WebDavSessionItem itemToCopy, Uri destinationUri, bool overwrite, bool throwException = false)
         {
@@ -442,6 +449,7 @@ namespace DecaTec.WebDav
         /// <param name="sourceUri">The source <see cref="Uri"/>.</param>
         /// <param name="destinationUri">The destination <see cref="Uri"/>.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> CopyAsync(Uri sourceUri, Uri destinationUri, bool overwrite, bool throwException)
         {
@@ -465,6 +473,7 @@ namespace DecaTec.WebDav
         /// Creates a directory at the URL specified.
         /// </summary>
         /// <param name="url">The URL of the directory to create.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> CreateDirectoryAsync(string url, bool throwException = false)
         {
@@ -475,6 +484,7 @@ namespace DecaTec.WebDav
         /// Creates a directory at the <see cref="Uri"/> specified.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory to create.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> CreateDirectoryAsync(Uri uri, bool throwException)
         {
@@ -497,6 +507,7 @@ namespace DecaTec.WebDav
         /// Deletes a directory or file at the URL specified.
         /// </summary>
         /// <param name="url">The URL of the directory or file to delete.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DeleteAsync(string url, bool throwException = false)
         {
@@ -507,6 +518,7 @@ namespace DecaTec.WebDav
         /// Deletes a directory or file specified by a <see cref="WebDavSessionItem"/>.
         /// </summary>
         /// <param name="itemToDelete">The <see cref="WebDavSessionItem"/> to delete.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DeleteAsync(WebDavSessionItem itemToDelete, bool throwException = false)
         {
@@ -517,6 +529,7 @@ namespace DecaTec.WebDav
         /// Deletes a directory or file at the <see cref="Uri"/> specified.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory or file to delete.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> DeleteAsync(Uri uri, bool throwException)
         {
@@ -540,6 +553,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileAsync(string url, Stream localStream, bool throwException = false)
         {
@@ -551,6 +565,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileAsync(Uri uri, Stream localStream, bool throwException = false)
         {
@@ -562,6 +577,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToDownload">The <see cref="WebDavSessionItem"/> to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream, bool throwException = false)
         {
@@ -574,6 +590,7 @@ namespace DecaTec.WebDav
         /// <param name="url">The URL of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileAsync(string url, Stream localStream, CancellationToken ct, bool throwException = false)
         {
@@ -586,6 +603,7 @@ namespace DecaTec.WebDav
         /// <param name="itemToDownload">The <see cref="WebDavSessionItem"/> to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileAsync(WebDavSessionItem itemToDownload, Stream localStream, CancellationToken ct, bool throwException = false)
         {
@@ -598,6 +616,7 @@ namespace DecaTec.WebDav
         /// <param name="uri">The <see cref="Uri"/> of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the file to.</param>
         /// <param name="ct">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> DownloadFileAsync(Uri uri, Stream localStream, CancellationToken ct, bool throwException)
         {
@@ -636,6 +655,7 @@ namespace DecaTec.WebDav
         /// <param name="url">Te URL of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
         {
@@ -648,6 +668,7 @@ namespace DecaTec.WebDav
         /// <param name="itemToDownload">The <see cref="WebDavSessionItem"/> to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
         {
@@ -661,6 +682,7 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileWithProgressAsync(string url, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
         {
@@ -674,6 +696,7 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param> 
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileWithProgressAsync(WebDavSessionItem itemToDownload, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
         {
@@ -686,6 +709,7 @@ namespace DecaTec.WebDav
         /// <param name="uri">Te <see cref="Uri"/> of the file to download.</param>
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress, bool throwException = false)
         {
@@ -699,6 +723,7 @@ namespace DecaTec.WebDav
         /// <param name="localStream">The <see cref="Stream"/> to save the downloaded file to.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> DownloadFileWithProgressAsync(Uri uri, Stream localStream, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException)
         {
@@ -720,6 +745,7 @@ namespace DecaTec.WebDav
         /// Checks if a file or directory exists at the URL specified.
         /// </summary>
         /// <param name="url">The URL to check.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> ExistsAsync(string url, bool throwException = false)
         {
@@ -730,6 +756,7 @@ namespace DecaTec.WebDav
         /// Checks if a file or directory exists at the <see cref="Uri"/> specified.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> to check.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> ExistsAsync(Uri uri, bool throwException)
         {
@@ -751,6 +778,7 @@ namespace DecaTec.WebDav
         /// Gets the WebDAV property names which are supported by the WebDAV server for the given <see cref="WebDavSessionItem"/>.
         /// </summary>
         /// <param name="item">The <see cref="WebDavSessionItem"/> to get the supported property names for.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
         public async Task<string[]> GetSupportedPropertyNamesAsync(WebDavSessionItem item, bool throwException = false)
@@ -762,6 +790,7 @@ namespace DecaTec.WebDav
         /// Gets the WebDAV property names which are supported by the WebDAV server for the element at the given URL.
         /// </summary>
         /// <param name="url">The URL to get the supported property names for.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
         public async Task<string[]> GetSupportedPropertyNamesAsync(string url, bool throwException = false)
@@ -773,6 +802,7 @@ namespace DecaTec.WebDav
         /// Gets the WebDAV property names which are supported by the WebDAV server for the element at the given <see cref="Uri"/>.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> to get the supported property names for.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>Not all WebDAV servers return all known property names upon such a request.</remarks>
         public async Task<string[]> GetSupportedPropertyNamesAsync(Uri uri, bool throwException)
@@ -798,6 +828,7 @@ namespace DecaTec.WebDav
         /// Retrieves a list of files and directories of the directory at the <see cref="Uri"/> specified (using 'allprop').
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory which content should be listed. Has to be an absolute URI (including the base URI) or a relative URI (relative to base URI).</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
@@ -810,6 +841,7 @@ namespace DecaTec.WebDav
         /// Retrieves a list of files and directories of the directory at the URL specified.
         /// </summary>
         /// <param name="url">The URL of the directory which content should be listed. Has to be an absolute URL (including the base URL) or a relative URL (relative to base URL).</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
@@ -822,6 +854,7 @@ namespace DecaTec.WebDav
         /// Retrieves a list of files and directories of the directory from the <see cref="WebDavSessionItem"/> specified
         /// </summary>
         /// <param name="item">The <see cref="WebDavSessionItem"/> which content should be listed.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>This method uses a so called 'allprop'. A server should return all known properties to the server.
         /// If not all of the expected properties are return by the server, use an overload of this method specifying a <see cref="PropFind"/> explicitly.</remarks>
@@ -835,6 +868,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the directory which content should be listed. Has to be an absolute URL (including the base URL) or a relative URL (relative to base URL).</param>
         /// <param name="propFind">The <see cref="PropFind"/> to use. Different PropFind  types can be created using the static methods of the class <see cref="PropFind"/>.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<IList<WebDavSessionItem>> ListAsync(string url, PropFind propFind)
         {
@@ -846,6 +880,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="item">The <see cref="WebDavSessionItem"/> which content should be listed. Has to be an absolute URI (including the base URI) or a relative URI (relative to base URI).</param>
         /// <param name="propFind">The <see cref="PropFind"/> to use. Different PropFind  types can be created using the static methods of the class <see cref="PropFind"/>.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<IList<WebDavSessionItem>> ListAsync(WebDavSessionItem item, PropFind propFind)
         {
@@ -857,6 +892,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the directory which content should be listed. Has to be an absolute URI (including the base URI) or a relative URI (relative to base URI).</param>
         /// <param name="propFind">The <see cref="PropFind"/> to use. Different PropFind  types can be created using the static methods of the class <see cref="PropFind"/>.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<IList<WebDavSessionItem>> ListAsync(Uri uri, PropFind propFind)
         {
@@ -1010,6 +1046,7 @@ namespace DecaTec.WebDav
         /// Locks a file or directory at the URL specified.
         /// </summary>
         /// <param name="url">The URL of the file or directory to lock.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> LockAsync(string url, bool throwException = false)
         {
@@ -1020,6 +1057,7 @@ namespace DecaTec.WebDav
         ///  Locks a file or directory specified as <see cref="WebDavSessionItem"/>.
         /// </summary>
         /// <param name="itemToLock">The <see cref="WebDavSessionItem"/> to lock.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> LockAsync(WebDavSessionItem itemToLock, bool throwException = false)
         {
@@ -1030,6 +1068,7 @@ namespace DecaTec.WebDav
         ///  Locks a file or directory at the URL specified.
         /// </summary>
         /// <param name="uri">The URI of the file or directory to lock.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> LockAsync(Uri uri, bool throwException)
         {
@@ -1093,6 +1132,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="sourceUrl">The URL of the source.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> MoveAsync(string sourceUrl, string destinationUrl, bool throwException = false)
         {
@@ -1104,6 +1144,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl, bool throwException = false)
         {
@@ -1115,6 +1156,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="sourceUri">The URI of the source.</param>
         /// <param name="destinationUri">The URL of the destination.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri, bool throwException = false)
         {
@@ -1126,6 +1168,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUri">The URL of the destination.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri, bool throwException = false)
         {
@@ -1138,6 +1181,7 @@ namespace DecaTec.WebDav
         /// <param name="sourceUrl">The URL of the source.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> MoveAsync(string sourceUrl, string destinationUrl, bool overwrite, bool throwException = false)
         {
@@ -1150,6 +1194,7 @@ namespace DecaTec.WebDav
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUrl">The URL of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> MoveAsync(WebDavSessionItem itemToMove, string destinationUrl, bool overwrite, bool throwException = false)
         {
@@ -1162,6 +1207,7 @@ namespace DecaTec.WebDav
         /// <param name="itemToMove">The <see cref="WebDavSessionItem"/> to move.</param>
         /// <param name="destinationUri">The <see cref="Uri"/> of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> MoveAsync(WebDavSessionItem itemToMove, Uri destinationUri, bool overwrite, bool throwException = false)
         {
@@ -1174,6 +1220,7 @@ namespace DecaTec.WebDav
         /// <param name="sourceUri">The <see cref="Uri"/> of the source.</param>
         /// <param name="destinationUri">The <see cref="Uri"/> of the destination.</param>
         /// <param name="overwrite">True, if an already existing resource should be overwritten, otherwise false.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> MoveAsync(Uri sourceUri, Uri destinationUri, bool overwrite, bool throwException)
         {
@@ -1271,6 +1318,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="url">The URL of the file to upload.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> UploadFileAsync(string url, Stream localStream, bool throwException = false)
         {
@@ -1283,6 +1331,7 @@ namespace DecaTec.WebDav
         /// <param name="folderToUploadTo">The folder as <see cref="WebDavSessionItem"/> to upload to.</param>
         /// <param name="fileName">The file name of the uploaded file.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> UploadFileAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream localStream, bool throwException = false)
         {
@@ -1298,6 +1347,7 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> of the file to upload.</param>
         /// <param name="localStream">The <see cref="Stream"/> containing the file to upload.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> UploadFileAsync(Uri uri, Stream localStream, bool throwException)
         {
@@ -1320,6 +1370,7 @@ namespace DecaTec.WebDav
         /// <param name="stream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
         {
@@ -1333,6 +1384,7 @@ namespace DecaTec.WebDav
         /// <param name="stream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
         {
@@ -1347,6 +1399,7 @@ namespace DecaTec.WebDav
         /// <param name="stream">The <see cref="Stream"/> containing the file to upload.</param>
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress, bool throwException = false)
         {
@@ -1361,6 +1414,7 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> UploadFileWithProgressAsync(string url, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
         {
@@ -1376,6 +1430,7 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<bool> UploadFileWithProgressAsync(WebDavSessionItem folderToUploadTo, string fileName, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException = false)
         {
@@ -1394,6 +1449,7 @@ namespace DecaTec.WebDav
         /// <param name="contentType">The content type of the file to upload.</param>
         /// <param name="progress">An object representing the progress of the operation.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <param name="throwException">Indicates throw exception on error or not.</param>
         /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<bool> UploadFileWithProgressAsync(Uri uri, Stream stream, string contentType, IProgress<WebDavProgress> progress, CancellationToken cancellationToken, bool throwException)
         {

--- a/DecaTec.WebDav/WebDavSession.cs
+++ b/DecaTec.WebDav/WebDavSession.cs
@@ -26,6 +26,8 @@ namespace DecaTec.WebDav
     /// URL/<see cref="System.Uri"/> will be relative on this base URL/<see cref="System.Uri"/>.
     /// If no base URL/<see cref="System.Uri"/> is specified, all operations has the be called with an absolute URL/<see cref="System.Uri"/>.</para>
     /// <para>The WebDavSession uses HTTP/2 by default. To use other HTTP versions, specify the HTTP version to use in an overloaded constructor of WebDavSession or set the HTTP version with the property <see cref="HttpVersion"/>.</para>
+    /// <para>The methods of WebDavSession often return a boolean value in order to indicate if the operation was completed successfully and to avoid throwing of exceptions. 
+    /// If you prefer that exceptions are thrown with more information about what went wrong, set the property <see cref="WebDavSession.ThrowExceptions"/> to true (defaults to false).</para>
     /// </remarks>
     /// <example>See the following code to list the content of a directory with the WebDavSession:
     /// <code>
@@ -90,8 +92,10 @@ namespace DecaTec.WebDav
         /// Initializes a new instance of WebDavSession with a default <see cref="HttpClientHandler"/>.
         /// </summary>
         /// <param name="credentials">The <see cref="ICredentials"/> to use.</param>
-        public WebDavSession(ICredentials credentials)
-            : this(new HttpClientHandler() { PreAuthenticate = true, Credentials = credentials })
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
+        public WebDavSession(ICredentials credentials, bool throwExceptions = false)
+            : this(new HttpClientHandler() { PreAuthenticate = true, Credentials = credentials }, throwExceptions)
         {
         }
 
@@ -100,8 +104,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="credentials">The <see cref="ICredentials"/> to use.</param>
         /// <param name="httpVersion">The HTTP <see cref="Version"/> to use for requests.</param>
-        public WebDavSession(ICredentials credentials, Version httpVersion)
-            : this(credentials)
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
+        public WebDavSession(ICredentials credentials, Version httpVersion, bool throwExceptions = false)
+            : this(credentials, throwExceptions)
         {
             this.webDavClient.HttpVersion = httpVersion;
         }
@@ -111,8 +117,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="baseUrl">The base URL to use for this WebDavSession.</param>
         /// <param name="credentials">The <see cref="ICredentials"/> to use.</param>
-        public WebDavSession(string baseUrl, ICredentials credentials)
-            : this(new Uri(baseUrl), new HttpClientHandler() { PreAuthenticate = true, Credentials = credentials })
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
+        public WebDavSession(string baseUrl, ICredentials credentials, bool throwExceptions = false)
+            : this(new Uri(baseUrl), new HttpClientHandler() { PreAuthenticate = true, Credentials = credentials }, throwExceptions)
         {
         }
 
@@ -122,8 +130,10 @@ namespace DecaTec.WebDav
         /// <param name="baseUrl">The base URL to use for this WebDavSession.</param>
         /// <param name="credentials">The <see cref="ICredentials"/> to use.</param>
         /// <param name="httpVersion">The HTTP <see cref="Version"/> to use for requests.</param>
-        public WebDavSession(string baseUrl, ICredentials credentials, Version httpVersion)
-            : this(baseUrl, credentials)
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
+        public WebDavSession(string baseUrl, ICredentials credentials, Version httpVersion, bool throwExceptions = false)
+            : this(baseUrl, credentials, throwExceptions)
         {
             this.webDavClient.HttpVersion = httpVersion;
         }
@@ -133,8 +143,10 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="baseUri">The base <see cref="Uri"/> to use for this WebDavSession.</param>
         /// <param name="credentials">The <see cref="ICredentials"/> to use.</param>
-        public WebDavSession(Uri baseUri, ICredentials credentials)
-            : this(baseUri, new HttpClientHandler() { PreAuthenticate = true, Credentials = credentials })
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
+        public WebDavSession(Uri baseUri, ICredentials credentials, bool throwExceptions = false)
+            : this(baseUri, new HttpClientHandler() { PreAuthenticate = true, Credentials = credentials }, throwExceptions)
         {
         }
 
@@ -144,8 +156,10 @@ namespace DecaTec.WebDav
         /// <param name="baseUri">The base <see cref="Uri"/> to use for this WebDavSession.</param>
         /// <param name="credentials">The <see cref="ICredentials"/> to use.</param>
         /// <param name="httpVersion">The HTTP <see cref="Version"/> to use for requests.</param>
-        public WebDavSession(Uri baseUri, ICredentials credentials, Version httpVersion)
-            : this(baseUri, credentials)
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
+        public WebDavSession(Uri baseUri, ICredentials credentials, Version httpVersion, bool throwExceptions = false)
+            : this(baseUri, credentials, throwExceptions)
         {
             this.webDavClient.HttpVersion = httpVersion;
         }
@@ -154,9 +168,11 @@ namespace DecaTec.WebDav
         /// Initializes a new instance of WebDavSession with the <see cref="HttpMessageHandler"/> specified.
         /// </summary>
         /// <param name="httpMessageHandler">The <see cref="HttpMessageHandler"/> to use with this WebDavSession.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        public WebDavSession(HttpMessageHandler httpMessageHandler)
-            : this(string.Empty, httpMessageHandler)
+        public WebDavSession(HttpMessageHandler httpMessageHandler, bool throwExceptions = false)
+            : this(string.Empty, httpMessageHandler, throwExceptions)
         {
         }
 
@@ -165,9 +181,11 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="httpMessageHandler">The <see cref="HttpMessageHandler"/> to use with this WebDavSession.</param>
         /// <param name="httpVersion">The HTTP <see cref="Version"/> to use for requests.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        public WebDavSession(HttpMessageHandler httpMessageHandler, Version httpVersion)
-            : this(httpMessageHandler)
+        public WebDavSession(HttpMessageHandler httpMessageHandler, Version httpVersion, bool throwExceptions = false)
+            : this(httpMessageHandler, throwExceptions)
         {
             this.webDavClient.HttpVersion = httpVersion;
         }
@@ -177,9 +195,11 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="baseUrl">The base URL to use for this WebDavSession.</param>
         /// <param name="httpMessageHandler">The <see cref="HttpMessageHandler"/> to use with this WebDavSession.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        public WebDavSession(string baseUrl, HttpMessageHandler httpMessageHandler)
-            : this(string.IsNullOrEmpty(baseUrl) ? null : new Uri(baseUrl), httpMessageHandler)
+        public WebDavSession(string baseUrl, HttpMessageHandler httpMessageHandler, bool throwExceptions = false)
+            : this(string.IsNullOrEmpty(baseUrl) ? null : new Uri(baseUrl), httpMessageHandler, throwExceptions)
         {
         }
 
@@ -189,9 +209,11 @@ namespace DecaTec.WebDav
         /// <param name="baseUrl">The base URL to use for this WebDavSession.</param>
         /// <param name="httpMessageHandler">The <see cref="HttpMessageHandler"/> to use with this WebDavSession.</param>
         /// <param name="httpVersion">The HTTP <see cref="Version"/> to use for requests.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        public WebDavSession(string baseUrl, HttpMessageHandler httpMessageHandler, Version httpVersion)
-            : this(baseUrl, httpMessageHandler)
+        public WebDavSession(string baseUrl, HttpMessageHandler httpMessageHandler, Version httpVersion, bool throwExceptions = false)
+            : this(baseUrl, httpMessageHandler, throwExceptions)
         {
             this.webDavClient.HttpVersion = httpVersion;
         }
@@ -201,9 +223,11 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="baseUri">The base <see cref="Uri"/> to use for this WebDavSession.</param>
         /// <param name="httpMessageHandler">The <see cref="HttpMessageHandler"/> to use with this WebDavSession.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        public WebDavSession(Uri baseUri, HttpMessageHandler httpMessageHandler)
-            : this(baseUri, httpMessageHandler, WebDavClient.DefaultHttpVersion)
+        public WebDavSession(Uri baseUri, HttpMessageHandler httpMessageHandler, bool throwExceptions = false)
+            : this(baseUri, httpMessageHandler, WebDavClient.DefaultHttpVersion, throwExceptions)
         {
         }
 
@@ -213,9 +237,12 @@ namespace DecaTec.WebDav
         /// <param name="baseUri">The base <see cref="Uri"/> to use for this WebDavSession.</param>
         /// <param name="httpMessageHandler">The <see cref="HttpMessageHandler"/> to use with this WebDavSession.</param>
         /// <param name="httpVersion">The HTTP <see cref="Version"/> to use for requests.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        public WebDavSession(Uri baseUri, HttpMessageHandler httpMessageHandler, Version httpVersion)
+        public WebDavSession(Uri baseUri, HttpMessageHandler httpMessageHandler, Version httpVersion, bool throwExceptions = false)
         {
+            this.ThrowExceptions = throwExceptions;
             this.permanentLocks = new ConcurrentDictionary<Uri, PermanentLock>();
             this.webDavClient = CreateWebDavClient(httpMessageHandler);
             this.webDavClient.HttpVersion = httpVersion;
@@ -227,9 +254,11 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="baseUrl">The base URL to use for this WebDavSession.</param>
         /// <param name="webDavClient">The base <see cref="WebDavClient"/> to use for this WebDavSession.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        protected WebDavSession(string baseUrl, WebDavClient webDavClient)
-            : this(string.IsNullOrEmpty(baseUrl) ? null : new Uri(baseUrl), webDavClient, WebDavClient.DefaultHttpVersion)
+        protected WebDavSession(string baseUrl, WebDavClient webDavClient, bool throwExceptions = false)
+            : this(string.IsNullOrEmpty(baseUrl) ? null : new Uri(baseUrl), webDavClient, WebDavClient.DefaultHttpVersion, throwExceptions)
         {
         }
 
@@ -239,9 +268,11 @@ namespace DecaTec.WebDav
         /// <param name="baseUrl">The base URL to use for this WebDavSession.</param>
         /// <param name="webDavClient">The base <see cref="WebDavClient"/> to use for this WebDavSession.</param>
         /// <param name="httpVersion">The HTTP <see cref="Version"/> to use for requests.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        protected WebDavSession(string baseUrl, WebDavClient webDavClient, Version httpVersion)
-            : this(string.IsNullOrEmpty(baseUrl) ? null : new Uri(baseUrl), webDavClient, httpVersion)
+        protected WebDavSession(string baseUrl, WebDavClient webDavClient, Version httpVersion, bool throwExceptions = false)
+            : this(string.IsNullOrEmpty(baseUrl) ? null : new Uri(baseUrl), webDavClient, httpVersion, throwExceptions)
         {
         }
 
@@ -250,9 +281,11 @@ namespace DecaTec.WebDav
         /// </summary>
         /// <param name="baseUri">The base <see cref="Uri"/> to use for this WebDavSession.</param>
         /// <param name="webDavClient">The base <see cref="WebDavClient"/> to use for this WebDavSession.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        protected WebDavSession(Uri baseUri, WebDavClient webDavClient)
-            : this(baseUri, webDavClient, WebDavClient.DefaultHttpVersion)
+        protected WebDavSession(Uri baseUri, WebDavClient webDavClient, bool throwExceptions = false)
+            : this(baseUri, webDavClient, WebDavClient.DefaultHttpVersion, throwExceptions)
         {
         }
 
@@ -262,9 +295,12 @@ namespace DecaTec.WebDav
         /// <param name="baseUri">The base <see cref="Uri"/> to use for this WebDavSession.</param>
         /// <param name="webDavClient">The base <see cref="WebDavClient"/> to use for this WebDavSession.</param>
         /// <param name="httpVersion">The HTTP <see cref="Version"/> to use for requests.</param>
+        /// <param name="throwExceptions">Indicates if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <remarks>If credentials are needed, these are part of the <see cref="HttpMessageHandler"/> and are specified with it.</remarks>
-        protected WebDavSession(Uri baseUri, WebDavClient webDavClient, Version httpVersion)
+        protected WebDavSession(Uri baseUri, WebDavClient webDavClient, Version httpVersion, bool throwExceptions = false)
         {
+            this.ThrowExceptions = throwExceptions;
             this.webDavClient = webDavClient;
             this.webDavClient.HttpVersion = httpVersion;
         }
@@ -349,12 +385,13 @@ namespace DecaTec.WebDav
             get;
             set;
         }
-
+        
+        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <summary>
-        /// Gets or sets how <see cref="WebDavSession"/> processing error response from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
+        /// Gets or sets a value indicating if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
         /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.
         /// </summary>
-        public bool ThrowException
+        public bool ThrowExceptions
         {
             get;
             set;
@@ -459,10 +496,9 @@ namespace DecaTec.WebDav
             destinationUri = UriHelper.CombineUri(this.BaseUri, destinationUri, true);
             var lockToken = GetAffectedLockToken(destinationUri);
             var response = await webDavClient.CopyAsync(sourceUri, destinationUri, overwrite, WebDavDepthHeaderValue.Infinity, lockToken);
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error copy file from '{sourceUri}' to '{destinationUri}'. Response: {response.ReasonPhrase}");
-            }
+
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error copying file from '{sourceUri}' to '{destinationUri}'. Response: {response.ReasonPhrase}");
 
             return response.IsSuccessStatusCode;
         }
@@ -491,10 +527,9 @@ namespace DecaTec.WebDav
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.MkcolAsync(uri, lockToken);
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error create directory '{uri}'. Response: {response.ReasonPhrase}");
-            }
+
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error creating directory '{uri}'. Response: {response.ReasonPhrase}");
 
             return response.IsSuccessStatusCode;
         }
@@ -533,10 +568,9 @@ namespace DecaTec.WebDav
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.DeleteAsync(uri, lockToken);
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error delete '{uri}'. Response: {response.ReasonPhrase}");
-            }
+
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error deleting '{uri}'. Response: {response.ReasonPhrase}");
 
             return response.IsSuccessStatusCode;
         }
@@ -613,10 +647,9 @@ namespace DecaTec.WebDav
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.GetAsync(uri, ct);
-            if ((!response.IsSuccessStatusCode || response.Content == null) && ThrowException)
-            {
-                throw new WebDavException($"Error download file '{uri}'. Response: {response.ReasonPhrase}");
-            }
+
+            if ((!response.IsSuccessStatusCode || response.Content == null) && ThrowExceptions)
+                throw new WebDavException($"Error downloading file '{uri}'. Response: {response.ReasonPhrase}");
 
             if (response.Content != null)
             {
@@ -628,10 +661,8 @@ namespace DecaTec.WebDav
                 }
                 catch (IOException exception)
                 {
-                    if (ThrowException)
-                    {
-                        throw new WebDavException($"Error download file '{uri}'. Message: {exception.Message}", exception);
-                    }
+                    if (ThrowExceptions)
+                        throw new WebDavException($"Error downloading file '{uri}'. Message: {exception.Message}", exception);
 
                     return false;
                 }
@@ -714,10 +745,9 @@ namespace DecaTec.WebDav
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.DownloadFileWithProgressAsync(uri, localStream, cancellationToken, progress);
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error download file '{uri}'. Response: {response.ReasonPhrase}");
-            }
+
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error downloading file '{uri}'. Response: {response.ReasonPhrase}");
 
             return response.IsSuccessStatusCode;
         }
@@ -745,7 +775,7 @@ namespace DecaTec.WebDav
         {
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var response = await this.webDavClient.HeadAsync(uri);
-            if (!response.IsSuccessStatusCode && ThrowException)
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
             {
                 throw new WebDavException($"Error check exists '{uri}'. Response: {response.ReasonPhrase}");
             }
@@ -790,10 +820,9 @@ namespace DecaTec.WebDav
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var propFind = PropFind.CreatePropFindWithPropName();
             var response = await this.webDavClient.PropFindAsync(uri, WebDavDepthHeaderValue.Zero, propFind);
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error find property {uri}. Response {response.ReasonPhrase}.");
-            }
+
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error during profind {uri}. Response {response.ReasonPhrase}.");
 
             var propertyNames = await WebDavHelper.GetPropertyNamesKnownAndUnknownFromMultiStatusContentAsync(response.Content);
 
@@ -1086,10 +1115,8 @@ namespace DecaTec.WebDav
             if (!this.permanentLocks.TryAdd(uri, permanentLock))
                 throw new WebDavException("Lock with lock root " + uri.ToString() + " already exists.");
 
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error lock {uri}. Response {response.ReasonPhrase}.");
-            }
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error locking {uri}. Response {response.ReasonPhrase}.");
 
             return response.IsSuccessStatusCode;
         }
@@ -1192,10 +1219,9 @@ namespace DecaTec.WebDav
             var lockTokenSource = GetAffectedLockToken(sourceUri);
             var lockTokenDestination = GetAffectedLockToken(destinationUri);
             var response = await this.webDavClient.MoveAsync(sourceUri, destinationUri, overwrite, lockTokenSource, lockTokenDestination);
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error move file from {sourceUri} to {destinationUri}. Response {response.ReasonPhrase}.");
-            }
+
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error moving file from {sourceUri} to {destinationUri}. Response {response.ReasonPhrase}.");
 
             return response.IsSuccessStatusCode;
         }
@@ -1315,10 +1341,9 @@ namespace DecaTec.WebDav
             var lockToken = GetAffectedLockToken(uri);
             var content = new StreamContent(localStream);
             var response = await this.webDavClient.PutAsync(uri, content, lockToken);
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error upload file {uri}. Response {response.ReasonPhrase}.");
-            }
+
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error uploading file {uri}. Response {response.ReasonPhrase}.");
 
             return response.IsSuccessStatusCode;
         }
@@ -1410,10 +1435,9 @@ namespace DecaTec.WebDav
             uri = UriHelper.CombineUri(this.BaseUri, uri, true);
             var lockToken = GetAffectedLockToken(uri);
             var response = await this.webDavClient.UploadFileWithProgressAsync(uri, stream, contentType, progress, cancellationToken, lockToken);
-            if (!response.IsSuccessStatusCode && ThrowException)
-            {
-                throw new WebDavException($"Error upload file {uri}. Response {response.ReasonPhrase}");
-            }
+
+            if (!response.IsSuccessStatusCode && ThrowExceptions)
+                throw new WebDavException($"Error uploading file {uri}. Response {response.ReasonPhrase}");
 
             return response.IsSuccessStatusCode;
         }

--- a/DecaTec.WebDav/WebDavSession.cs
+++ b/DecaTec.WebDav/WebDavSession.cs
@@ -386,7 +386,6 @@ namespace DecaTec.WebDav
             set;
         }
         
-        /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.</param>
         /// <summary>
         /// Gets or sets a value indicating if <see cref="WebDavSession"/> should process error responses from server. If value is <b>true</b> will throw <see cref="WebDavException"/>; 
         /// otherwise returns result of operation and caller must check it. Default value is <b>false</b>.

--- a/Documentation/DecaTec.WebDav.Documentation/Content/VersionHistory/VersionHistory.aml
+++ b/Documentation/DecaTec.WebDav.Documentation/Content/VersionHistory/VersionHistory.aml
@@ -152,6 +152,18 @@
             </para>
           </listItem>
 
+          <listItem>
+            <para>
+              <link xlink:href="26b2f7f7-df3d-4dd1-855c-5a67e7e242c2" />
+            </para>
+          </listItem>
+
+          <listItem>
+            <para>
+              <link xlink:href="2c75c0c1-ce03-430b-9f26-63c9ed4b288a" />
+            </para>
+          </listItem>
+
         </list>
 
       </content>

--- a/Documentation/DecaTec.WebDav.Documentation/Content/VersionHistory/v1.1.4.0.aml
+++ b/Documentation/DecaTec.WebDav.Documentation/Content/VersionHistory/v1.1.4.0.aml
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<topic id="2c75c0c1-ce03-430b-9f26-63c9ed4b288a" revisionNumber="1">
+  <developerConceptualDocument
+    xmlns="http://ddue.schemas.microsoft.com/authoring/2003/5"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+    <introduction></introduction>
+
+    <section>
+      <title>Changes in release v1.1.4.0</title>
+      <content>
+
+        <list class="bullet">
+
+          <listItem>
+            <para>
+              WebDavSession: New property ThrowExceptions: The methods of WebDavSession usually only return a boolean value indicating if the operation completed successfully. If more information about a failed operation is needed, the WebDvSession has a new property ThrowExceptions.
+              If set to true, errors during WebDAV operations are thrown as exceptions. This property defaults to false.
+            </para>
+          </listItem>
+
+          <listItem>
+            <para>
+              WebDavSession: All constructors now have an optional parameter throwExceptions which defaults to false.
+            </para>
+          </listItem>
+
+          <listItem>
+            <para>
+              WebDavSession/WebDavClient: Removed unnecessary async calls in overloads of methods.
+            </para>
+          </listItem>
+
+        </list>
+
+      </content>
+    </section>
+
+    <relatedTopics>
+      <link xlink:href="55c4b378-829f-44e2-af56-20a587c2d24b" />
+    </relatedTopics>
+  </developerConceptualDocument>
+</topic>

--- a/Documentation/DecaTec.WebDav.Documentation/ContentLayout.content
+++ b/Documentation/DecaTec.WebDav.Documentation/ContentLayout.content
@@ -169,7 +169,7 @@
         <HelpKeyword index="K" term="version, 1.1.3.0" />
       </HelpKeywords>
     </Topic>
-    <Topic id="2c75c0c1-ce03-430b-9f26-63c9ed4b288a" visible="True" isSelected="true" title="Version 1.1.4.0" linkText="Version 1.1.3.0">
+    <Topic id="2c75c0c1-ce03-430b-9f26-63c9ed4b288a" visible="True" isSelected="true" title="Version 1.1.4.0" linkText="Version 1.1.4.0">
       <HelpKeywords>
         <HelpKeyword index="K" term="version, 1.1.4.0" />
       </HelpKeywords>

--- a/Documentation/DecaTec.WebDav.Documentation/ContentLayout.content
+++ b/Documentation/DecaTec.WebDav.Documentation/ContentLayout.content
@@ -164,9 +164,14 @@
         <HelpKeyword index="K" term="version, 1.1.2.0" />
       </HelpKeywords>
     </Topic>
-    <Topic id="26b2f7f7-df3d-4dd1-855c-5a67e7e242c2" visible="True" isSelected="true" title="Version 1.1.3.0" linkText="Version 1.1.3.0">
+    <Topic id="26b2f7f7-df3d-4dd1-855c-5a67e7e242c2" visible="True" title="Version 1.1.3.0" linkText="Version 1.1.3.0">
       <HelpKeywords>
         <HelpKeyword index="K" term="version, 1.1.3.0" />
+      </HelpKeywords>
+    </Topic>
+    <Topic id="2c75c0c1-ce03-430b-9f26-63c9ed4b288a" visible="True" isSelected="true" title="Version 1.1.4.0" linkText="Version 1.1.3.0">
+      <HelpKeywords>
+        <HelpKeyword index="K" term="version, 1.1.4.0" />
       </HelpKeywords>
     </Topic>
   </Topic>

--- a/Documentation/DecaTec.WebDav.Documentation/DecaTec.WebDav.Documentation.shfbproj
+++ b/Documentation/DecaTec.WebDav.Documentation/DecaTec.WebDav.Documentation.shfbproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- The configuration and platform will be used to determine which assemblies to include from solution and
 				 project documentation sources -->

--- a/Documentation/DecaTec.WebDav.Documentation/DecaTec.WebDav.Documentation.shfbproj
+++ b/Documentation/DecaTec.WebDav.Documentation/DecaTec.WebDav.Documentation.shfbproj
@@ -122,6 +122,7 @@
     <None Include="Content\VersionHistory\v1.1.1.0.aml" />
     <None Include="Content\VersionHistory\v1.1.2.0.aml" />
     <None Include="Content\VersionHistory\v1.1.3.0.aml" />
+    <None Include="Content\VersionHistory\v1.1.4.0.aml" />
     <None Include="Content\VersionHistory\VersionHistory.aml" />
     <None Include="Content\Welcome.aml" />
   </ItemGroup>

--- a/UnitTests/DecaTec.WebDav.UnitIntegrationTest/DecaTec.WebDav.UnitIntegrationTest.csproj
+++ b/UnitTests/DecaTec.WebDav.UnitIntegrationTest/DecaTec.WebDav.UnitIntegrationTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UnitTests/DecaTec.WebDav.UnitIntegrationTest/DecaTec.WebDav.UnitIntegrationTest.csproj
+++ b/UnitTests/DecaTec.WebDav.UnitIntegrationTest/DecaTec.WebDav.UnitIntegrationTest.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.17" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.17" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/DecaTec.WebDav.UnitTest/DecaTec.WebDav.UnitTest.csproj
+++ b/UnitTests/DecaTec.WebDav.UnitTest/DecaTec.WebDav.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UnitTests/DecaTec.WebDav.UnitTest/DecaTec.WebDav.UnitTest.csproj
+++ b/UnitTests/DecaTec.WebDav.UnitTest/DecaTec.WebDav.UnitTest.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.17" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.17" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="1.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/DecaTec.WebDav.UnitTest/UnitTestWebDavSession.cs
+++ b/UnitTests/DecaTec.WebDav.UnitTest/UnitTestWebDavSession.cs
@@ -1,4 +1,5 @@
-﻿using DecaTec.WebDav.Headers;
+﻿using DecaTec.WebDav.Exceptions;
+using DecaTec.WebDav.Headers;
 using DecaTec.WebDav.MessageHandlers;
 using DecaTec.WebDav.Tools;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -124,6 +125,37 @@ namespace DecaTec.WebDav.UnitTest
                 var list = session.ListAsync(WebDavRootFolder).Result;
 
                 Assert.IsNotNull(list);
+            }
+        }
+
+        [TestMethod]
+        public void UT_WebDavSession_ShouldThrowException()
+        {
+            var testFileUrl = UriHelper.CombineUrl(WebDavRootFolder, TestFile, true);
+
+            var mockHandler = new MockHttpMessageHandler();
+            mockHandler.When(HttpMethod.Delete, testFileUrl).Respond(HttpStatusCode.InternalServerError);
+
+            using (var session = CreateWebDavSession(mockHandler))
+            {
+                session.ThrowExceptions = true;
+                Assert.ThrowsExceptionAsync<WebDavException>(() => session.DeleteAsync(testFileUrl));
+            }
+        }
+
+        [TestMethod]
+        public void UT_WebDavSession_ShouldNotThrowException()
+        {
+            var testFileUrl = UriHelper.CombineUrl(WebDavRootFolder, TestFile, true);
+
+            var mockHandler = new MockHttpMessageHandler();
+            mockHandler.When(HttpMethod.Delete, testFileUrl).Respond(HttpStatusCode.InternalServerError);
+
+            using (var session = CreateWebDavSession(mockHandler))
+            {
+                var successs = session.DeleteAsync(TestFile).Result;
+
+                Assert.IsFalse(successs);
             }
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+v1.1.4.0
+- WebDavSession: New property ThrowExceptions: The methods of WebDavSession usually only return a boolean value indicating if the operation completed successfully. If more information about a failed operation is needed, the WebDvSession has a new property ThrowExceptions. If set to true, errors during WebDAV operations are thrown as exceptions. This property defaults to false.
+- WebDavSession: All constructors now have an optional parameter throwExceptions which defaults to false.
+- WebDavSession/WebDavClient: Removed unnecessary async calls in overloads of methods.
+
 v1.1.3.0
 - WebDavSession: New overload for DownloadFileWithProgressAsync accepting a WebDavSessionItem to download.
 - WebDavClient: Added missing method overloads.


### PR DESCRIPTION
Currently WebSession returns `Task<bool>` and caller must check result. I suggest throw exception in case error response from WebDAV. To capability with existing code I added parameter `throwException` with default value is `false`. So, all existing code will produce with old expected behavior, and new code can choose uses exceptions or checks result.